### PR TITLE
fix: omdøb Overnatningshave til Elins Have

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # System Arkitektur
 
-Visuel guide til backend arkitekturen for Elins Overnatningshave.
+Visuel guide til backend arkitekturen for Elins Have.
 
 ## 🏛️ High-Level Arkitektur
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Elins Overnatningshave
+# Elins Have
 
-En hjemmeside og API til Elins overnatningshave, hvor cyklister kan booke overnatning i en smuk have i Ribe.
+En hjemmeside og API til Elins Have, hvor cyklister kan booke overnatning i en smuk have i Ribe.
 
 ## Tech Stack
 

--- a/api/index.js
+++ b/api/index.js
@@ -346,7 +346,7 @@ var EmailService = class {
       const mailOptions = {
         from: config.email.from,
         to: email,
-        subject: "Tak for din foresp\xF8rgsel - Elins Overnatningshave",
+        subject: "Tak for din foresp\xF8rgsel - Elins Have",
         html: `
           <h2>Tak for din foresp\xF8rgsel</h2>
           <p>K\xE6re ${name},</p>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/tent-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Overnat i Elins smukke have - perfekt til cyklister på eventyr gennem Danmark" />
-    <title>Elins Overnatningshave - Cykelferie i naturskønne omgivelser</title>
+    <title>Elins Have - Overnatning for cyklister i Ribe</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "overnatihaven",
   "version": "1.0.0",
-  "description": "Website for Elins overnatningshave - camping in a beautiful garden",
+  "description": "Website for Elins Have - camping in a beautiful garden",
   "main": "index.js",
   "scripts": {
     "dev": "vite",

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Server Directory
 
-Dette directory indeholder al backend kode til Elins Overnatningshave.
+Dette directory indeholder al backend kode til Elins Have.
 
 ## 📁 Struktur
 

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -80,7 +80,7 @@ class EmailService {
       const mailOptions = {
         from: config.email.from,
         to: email,
-        subject: 'Tak for din forespørgsel - Elins Overnatningshave',
+        subject: 'Tak for din forespørgsel - Elins Have',
         html: `
           <h2>Tak for din forespørgsel</h2>
           <p>Kære ${name},</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -161,7 +161,7 @@ const Footer = () => {
         <div className="border-t border-gray-800 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-gray-400 text-sm mb-4 md:mb-0">
-              © {currentYear} Elins Overnatningshave. Alle rettigheder forbeholdes.
+              © {currentYear} Elins Have. Alle rettigheder forbeholdes.
             </p>
 
             {/* Social Icons */}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -139,7 +139,7 @@ const Hero = () => {
         <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
           Velkommen til
           <br />
-          <span className="text-primary-200">Elins Overnatningshave</span>
+          <span className="text-primary-200">Elins Have</span>
         </h1>
         <p className="text-xl sm:text-2xl md:text-3xl mb-8 text-primary-50 max-w-3xl mx-auto">
           En smuk og fredelig oase for cyklister på eventyr


### PR DESCRIPTION
## Summary
- Erstatter "Elins Overnatningshave" med "Elins Have" på tværs af hele sitet (hero, footer, email-emner, meta-tags, docs)
- Opdaterer sidetitel til "Elins Have - Overnatning for cyklister i Ribe"

## Test plan
- [ ] Tjek hero-overskriften viser "Velkommen til Elins Have"
- [ ] Tjek footer copyright viser "Elins Have"
- [ ] Tjek browserfanens titel er opdateret
- [ ] Verificer preview-deployment ser korrekt ud

🤖 Generated with [Claude Code](https://claude.com/claude-code)