### PR TITLE
feat: dark mode i admin-panel og Google Maps-link på adresse

### DIFF
--- a/e2e/admin-darkmode.spec.ts
+++ b/e2e/admin-darkmode.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = 'http://localhost:3000/api';
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${API_URL}/test/reset`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test.describe('Admin dark mode', () => {
+  test('html-elementet har klassen dark', async ({ page }) => {
+    await page.goto('/admin/login');
+    const htmlClass = await page.locator('html').getAttribute('class');
+    expect(htmlClass).toContain('dark');
+  });
+
+  test('sidebar har dark mode baggrund efter login', async ({ page }) => {
+    await page.goto('/admin/login');
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'admin123');
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL(/\/admin/);
+
+    const sidebar = page.locator('.w-64');
+    await expect(sidebar).toBeVisible();
+
+    const hasDarkBg = await sidebar.evaluate((el) => {
+      return el.classList.contains('dark:bg-gray-800') ||
+        window.getComputedStyle(el).backgroundColor === 'rgb(31, 41, 55)';
+    });
+    expect(hasDarkBg).toBeTruthy();
+  });
+
+  test('login-siden har dark mode baggrund', async ({ page }) => {
+    await page.goto('/admin/login');
+
+    const hasDarkBg = await page.locator('html').evaluate((el) => {
+      return el.classList.contains('dark');
+    });
+    expect(hasDarkBg).toBeTruthy();
+
+    await expect(page.locator('h2:has-text("Admin Login")')).toBeVisible();
+  });
+});

--- a/e2e/contact-maps.spec.ts
+++ b/e2e/contact-maps.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = 'http://localhost:3000/api';
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${API_URL}/test/reset`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test.describe('Google Maps link i kontakt-sektionen', () => {
+  test('Google Maps-link i kontaktsektionen har korrekt href og target', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('#contact').scrollIntoViewIfNeeded();
+
+    const mapsLink = page.locator('a[aria-label="Åbn i Google Maps"]').first();
+    await expect(mapsLink).toBeVisible();
+
+    const href = await mapsLink.getAttribute('href');
+    expect(href).toContain('google.com/maps');
+    expect(href).toContain('Gredstedbro');
+
+    const target = await mapsLink.getAttribute('target');
+    expect(target).toBe('_blank');
+
+    const rel = await mapsLink.getAttribute('rel');
+    expect(rel).toContain('noopener');
+  });
+});

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -13,9 +13,9 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
   const isActive = (path: string) => location.pathname === path
 
   return (
-    <div className="min-h-screen bg-gray-100 flex">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex">
       {/* Sidebar */}
-      <div className="w-64 bg-white shadow-lg flex-shrink-0 flex flex-col">
+      <div className="w-64 bg-white dark:bg-gray-800 shadow-lg flex-shrink-0 flex flex-col">
         <div className="flex items-center justify-center h-16 px-4 bg-primary-600">
           <h1 className="text-xl font-bold text-white">Admin Panel</h1>
         </div>
@@ -26,8 +26,8 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               to="/admin"
               className={`flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors ${
                 isActive('/admin')
-                  ? 'bg-primary-100 text-primary-700'
-                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
               }`}
             >
               <svg
@@ -50,8 +50,8 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               to="/admin/inquiries"
               className={`flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors ${
                 isActive('/admin/inquiries')
-                  ? 'bg-primary-100 text-primary-700'
-                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
               }`}
             >
               <svg
@@ -74,8 +74,8 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               to="/admin/facilities"
               className={`flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors ${
                 isActive('/admin/facilities')
-                  ? 'bg-primary-100 text-primary-700'
-                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
               }`}
             >
               <svg
@@ -98,8 +98,8 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               to="/admin/contacts"
               className={`flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors ${
                 isActive('/admin/contacts')
-                  ? 'bg-primary-100 text-primary-700'
-                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
               }`}
             >
               <svg
@@ -121,7 +121,7 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         </nav>
         
         {/* User info and logout */}
-        <div className="p-4 border-t border-gray-200">
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
           <div className="flex items-center mb-3">
             <div className="flex-shrink-0">
               <div className="h-8 w-8 rounded-full bg-primary-500 flex items-center justify-center">
@@ -131,8 +131,8 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               </div>
             </div>
             <div className="ml-3">
-              <p className="text-sm font-medium text-gray-700">{user?.username}</p>
-              <p className="text-xs text-gray-500">{user?.email}</p>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">{user?.username}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">{user?.email}</p>
             </div>
           </div>
           <button
@@ -160,11 +160,11 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       {/* Main content */}
       <div className="flex-1 flex flex-col">
         {/* Top bar */}
-        <div className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+        <div className="sticky top-0 z-40 bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
           <div className="px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between h-16">
               <div className="flex items-center">
-                <h1 className="text-xl font-semibold text-gray-900">
+                <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
                   {isActive('/admin') && 'Galleri Administration'}
                   {isActive('/admin/inquiries') && 'Forespørgsler'}
                   {isActive('/admin/contacts') && 'Kontaktbeskeder'}
@@ -175,7 +175,7 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               <div className="flex items-center space-x-4">
                 <Link
                   to="/"
-                  className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                  className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
                 >
                   <svg
                     className="inline-block w-4 h-4 mr-1"

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -106,6 +106,18 @@ const Contact = () => {
                     <p className="text-gray-600 dark:text-gray-300 mt-1">Mejerivej 3, Gredsted</p>
                     <p className="text-gray-600 dark:text-gray-300">6771 Gredstedbro</p>
                     <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Danmark</p>
+                    <a
+                      href="https://www.google.com/maps/search/?api=1&query=Mejerivej+3,+6771+Gredstedbro"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="Åbn i Google Maps"
+                      className="inline-flex items-center mt-2 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 transition-colors"
+                    >
+                      <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                      Åbn i Google Maps
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/components/ContactsAdmin.tsx
+++ b/src/components/ContactsAdmin.tsx
@@ -107,8 +107,8 @@ const ContactsAdmin: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Kontaktbeskeder</h2>
-            <p className="mt-1 text-sm text-gray-600">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Kontaktbeskeder</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
               Administrer beskeder fra kontaktformularen
             </p>
           </div>
@@ -116,34 +116,34 @@ const ContactsAdmin: React.FC = () => {
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+        <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
           {error}
         </div>
       )}
 
       {/* Contacts List */}
-      <div className="bg-white shadow overflow-hidden sm:rounded-md">
-        <ul className="divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-md">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {contacts.length === 0 ? (
-            <li className="px-6 py-4 text-center text-gray-500">
+            <li className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">
               Ingen beskeder fundet
             </li>
           ) : (
             contacts.map((contact) => (
-              <li key={contact.id} className="px-6 py-4 hover:bg-gray-50">
+              <li key={contact.id} className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-3">
                       <div>
-                        <p className="text-sm font-medium text-gray-900">
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">
                           {contact.name}
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           {contact.email}
                         </p>
                       </div>
                       {contact.is_read === 0 && (
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400">
                           Ny
                         </span>
                       )}
@@ -151,19 +151,19 @@ const ContactsAdmin: React.FC = () => {
                     
                     {contact.subject && (
                       <div className="mt-2">
-                        <p className="text-sm font-medium text-gray-700">
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
                           Emne: {contact.subject}
                         </p>
                       </div>
                     )}
                     
                     <div className="mt-2">
-                      <p className="text-sm text-gray-600 whitespace-pre-wrap">
+                      <p className="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
                         {contact.message}
                       </p>
                     </div>
                     
-                    <div className="mt-2 text-xs text-gray-400">
+                    <div className="mt-2 text-xs text-gray-400 dark:text-gray-500">
                       Modtaget: {new Date(contact.created_at).toLocaleDateString('da-DK')} kl. {new Date(contact.created_at).toLocaleTimeString('da-DK')}
                     </div>
                   </div>

--- a/src/components/FacilitiesAdmin.tsx
+++ b/src/components/FacilitiesAdmin.tsx
@@ -121,8 +121,8 @@ const FacilitiesAdmin: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Faciliteter Administration</h2>
-            <p className="mt-1 text-sm text-gray-600">Administrer faciliteter der vises på forsiden</p>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Faciliteter Administration</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Administrer faciliteter der vises på forsiden</p>
           </div>
           <button
             onClick={() => { setEditingFacility(null); setShowModal(true) }}
@@ -137,15 +137,15 @@ const FacilitiesAdmin: React.FC = () => {
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+        <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
           {error}
         </div>
       )}
 
-      <div className="bg-white shadow overflow-hidden sm:rounded-md">
-        <ul className="divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-md">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {facilities.length === 0 ? (
-            <li className="px-6 py-4 text-center text-gray-500">Ingen faciliteter fundet</li>
+            <li className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">Ingen faciliteter fundet</li>
           ) : (
             facilities.map((facility, index) => (
               <li
@@ -154,27 +154,27 @@ const FacilitiesAdmin: React.FC = () => {
                 onDragStart={(e) => handleDragStart(e, index)}
                 onDragOver={handleDragOver}
                 onDrop={(e) => handleDrop(e, index)}
-                className="px-6 py-4 hover:bg-gray-50 cursor-move transition-colors"
+                className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-move transition-colors"
               >
                 <div className="flex items-center space-x-4">
                   {/* Drag handle */}
                   <div className="flex-shrink-0 cursor-grab active:cursor-grabbing">
-                    <svg className="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="h-5 w-5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                     </svg>
                   </div>
 
                   {/* Info */}
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900">{facility.title}</p>
-                    <p className="text-sm text-gray-500">{facility.description || 'Ingen beskrivelse'}</p>
+                    <p className="text-sm font-medium text-gray-900 dark:text-white">{facility.title}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">{facility.description || 'Ingen beskrivelse'}</p>
                     <div className="flex items-center mt-1 space-x-4">
                       <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        facility.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+                        facility.is_active ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400' : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
                       }`}>
                         {facility.is_active ? 'Aktiv' : 'Inaktiv'}
                       </span>
-                      <span className="text-xs text-gray-400">Ikon: {facility.icon_name}</span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">Ikon: {facility.icon_name}</span>
                     </div>
                   </div>
 
@@ -306,64 +306,64 @@ const FacilityModal: React.FC<FacilityModalProps> = ({ facility, onClose, onSucc
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen px-4">
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75" onClick={onClose} />
-        <div className="relative bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80" onClick={onClose} />
+        <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
             {facility ? 'Rediger facilitet' : 'Ny facilitet'}
           </h3>
 
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded text-sm">
+            <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded text-sm">
               {error}
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Titel *</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Titel *</label>
               <input
                 type="text"
                 value={title}
                 onChange={e => setTitle(e.target.value)}
-                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="Facilitets titel"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Beskrivelse</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Beskrivelse</label>
               <textarea
                 value={description}
                 onChange={e => setDescription(e.target.value)}
                 rows={2}
-                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                 placeholder="Kort beskrivelse"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Ikon *</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Ikon *</label>
               <div className="flex items-center space-x-3 mb-2">
-                <div className="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center text-primary-600">
+                <div className="w-10 h-10 bg-primary-100 dark:bg-primary-900/30 rounded-lg flex items-center justify-center text-primary-600 dark:text-primary-400">
                   <IconPreview name={selectedIcon} />
                 </div>
-                <span className="text-sm text-gray-600">Valgt: {selectedIcon}</span>
+                <span className="text-sm text-gray-600 dark:text-gray-400">Valgt: {selectedIcon}</span>
               </div>
               <input
                 type="text"
                 value={iconSearch}
                 onChange={e => setIconSearch(e.target.value)}
-                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-2"
+                className="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-2"
                 placeholder="Søg ikon..."
               />
-              <div className="grid grid-cols-8 gap-1 max-h-40 overflow-y-auto border border-gray-200 rounded-md p-2">
+              <div className="grid grid-cols-8 gap-1 max-h-40 overflow-y-auto border border-gray-200 dark:border-gray-600 rounded-md p-2 dark:bg-gray-700">
                 {filteredIcons.map(icon => (
                   <button
                     key={icon}
                     type="button"
                     onClick={() => setSelectedIcon(icon)}
-                    className={`p-2 rounded hover:bg-gray-100 flex items-center justify-center ${
-                      selectedIcon === icon ? 'bg-primary-100 text-primary-600' : 'text-gray-600'
+                    className={`p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-600 flex items-center justify-center ${
+                      selectedIcon === icon ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400' : 'text-gray-600 dark:text-gray-400'
                     }`}
                     title={icon}
                   >
@@ -377,7 +377,7 @@ const FacilityModal: React.FC<FacilityModalProps> = ({ facility, onClose, onSucc
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600"
               >
                 Annuller
               </button>

--- a/src/components/GalleryAdmin.tsx
+++ b/src/components/GalleryAdmin.tsx
@@ -196,8 +196,8 @@ const GalleryAdmin: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Galleri Administration</h2>
-            <p className="mt-1 text-sm text-gray-600">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Galleri Administration</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
               Administrer billeder i galleriet
             </p>
           </div>
@@ -224,16 +224,16 @@ const GalleryAdmin: React.FC = () => {
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+        <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
           {error}
         </div>
       )}
 
       {/* Images Grid */}
-      <div className="bg-white shadow overflow-hidden sm:rounded-md">
-        <ul className="divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-md">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {images.length === 0 ? (
-            <li className="px-6 py-4 text-center text-gray-500">
+            <li className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">
               Ingen billeder fundet
             </li>
           ) : (
@@ -244,13 +244,13 @@ const GalleryAdmin: React.FC = () => {
                 onDragStart={(e) => handleDragStart(e, index)}
                 onDragOver={handleDragOver}
                 onDrop={(e) => handleDrop(e, index)}
-                className="px-6 py-4 hover:bg-gray-50 cursor-move transition-colors"
+                className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-move transition-colors"
               >
                 <div className="flex items-center space-x-4">
                   {/* Drag handle */}
                   <div className="flex-shrink-0 cursor-grab active:cursor-grabbing">
                     <svg
-                      className="h-5 w-5 text-gray-400"
+                      className="h-5 w-5 text-gray-400 dark:text-gray-500"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -275,26 +275,26 @@ const GalleryAdmin: React.FC = () => {
 
                   {/* Image info */}
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 truncate">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                       {image.title}
                     </p>
-                    <p className="text-sm text-gray-500 truncate">
+                    <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
                       {image.description || 'Ingen beskrivelse'}
                     </p>
                     <div className="flex items-center mt-1 space-x-4">
                       <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                         image.is_active
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-800'
+                          ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
                       }`}>
                         {image.is_active ? 'Aktiv' : 'Inaktiv'}
                       </span>
                       {image.show_in_hero && (
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400">
                           Hero
                         </span>
                       )}
-                      <span className="text-xs text-gray-500">
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
                         Rækkefølge: {image.sort_order}
                       </span>
                     </div>

--- a/src/components/ImageEditModal.tsx
+++ b/src/components/ImageEditModal.tsx
@@ -71,27 +71,27 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
         <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose}></div>
 
         {/* Modal panel */}
-        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div className="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
           <form onSubmit={handleSubmit}>
-            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
               <div className="mb-4">
-                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
                   Rediger billede
                 </h3>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
                   Opdater information for billedet
                 </p>
               </div>
 
               {error && (
-                <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+                <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
                   {error}
                 </div>
               )}
 
               {/* Current image preview */}
               <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Nuværende billede
                 </label>
                 <img
@@ -103,7 +103,7 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
 
               {/* Title */}
               <div className="mb-4">
-                <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Titel *
                 </label>
                 <input
@@ -112,14 +112,14 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
                   required
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="Billedets titel"
                 />
               </div>
 
               {/* Description */}
               <div className="mb-4">
-                <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Beskrivelse
                 </label>
                 <textarea
@@ -127,14 +127,14 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
                   rows={3}
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="Kort beskrivelse af billedet"
                 />
               </div>
 
               {/* Image URL */}
               <div className="mb-4">
-                <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Billede URL
                 </label>
                 <input
@@ -142,7 +142,7 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
                   id="imageUrl"
                   value={imageUrl}
                   onChange={(e) => setImageUrl(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="https://eksempel.com/billede.jpg"
                 />
               </div>
@@ -157,15 +157,15 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
                     onChange={(e) => setIsActive(e.target.checked)}
                     className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
                   />
-                  <label htmlFor="isActive" className="ml-2 block text-sm text-gray-900">
+                  <label htmlFor="isActive" className="ml-2 block text-sm text-gray-900 dark:text-white">
                     Vis billede på hjemmesiden
                   </label>
                 </div>
               </div>
 
               {/* Additional info */}
-              <div className="mt-4 p-3 bg-gray-50 rounded-md">
-                <p className="text-xs text-gray-500">
+              <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   <strong>Oprettet:</strong> {new Date(image.created_at).toLocaleDateString('da-DK')}<br />
                   <strong>Opdateret:</strong> {new Date(image.updated_at).toLocaleDateString('da-DK')}<br />
                   <strong>Rækkefølge:</strong> {image.sort_order}
@@ -174,7 +174,7 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
             </div>
 
             {/* Modal actions */}
-            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+            <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
               <button
                 type="submit"
                 disabled={isLoading || !title}
@@ -193,7 +193,7 @@ const ImageEditModal: React.FC<ImageEditModalProps> = ({ image, onClose, onSucce
                 type="button"
                 onClick={onClose}
                 disabled={isLoading}
-                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
               >
                 Annuller
               </button>

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -127,27 +127,27 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
         <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose}></div>
 
         {/* Modal panel */}
-        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div className="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
           <form onSubmit={handleSubmit}>
-            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
               <div className="mb-4">
-                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
                   Tilføj nyt billede
                 </h3>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
                   Upload en billedfil eller indtast en URL til et billede
                 </p>
               </div>
 
               {error && (
-                <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+                <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
                   {error}
                 </div>
               )}
 
               {/* Title */}
               <div className="mb-4">
-                <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Titel *
                 </label>
                 <input
@@ -156,14 +156,14 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
                   required
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="Billedets titel"
                 />
               </div>
 
               {/* Description */}
               <div className="mb-4">
-                <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Beskrivelse
                 </label>
                 <textarea
@@ -171,14 +171,14 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
                   rows={3}
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="Kort beskrivelse af billedet"
                 />
               </div>
 
               {/* File Upload */}
               <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Upload billede
                 </label>
                 <div className="flex items-center space-x-2">
@@ -192,11 +192,11 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
                   />
                   <label
                     htmlFor="file-upload"
-                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                    className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
                   >
                     Vælg fil
                   </label>
-                  <span className="text-sm text-gray-500">
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
                     {file ? file.name : 'Ingen fil valgt'}
                   </span>
                 </div>
@@ -204,7 +204,7 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
 
               {/* URL Input */}
               <div className="mb-4">
-                <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Eller indtast billede URL
                 </label>
                 <input
@@ -212,7 +212,7 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
                   id="imageUrl"
                   value={imageUrl}
                   onChange={handleUrlChange}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                   placeholder="https://eksempel.com/billede.jpg"
                 />
               </div>
@@ -220,7 +220,7 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
               {/* Preview */}
               {preview && (
                 <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Forhåndsvisning
                   </label>
                   <div className="relative">
@@ -246,10 +246,10 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
               {isLoading && uploadProgress > 0 && (
                 <div className="mb-4">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-sm text-gray-700">Upload progress</span>
-                    <span className="text-sm text-gray-700">{uploadProgress}%</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-300">Upload progress</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{uploadProgress}%</span>
                   </div>
-                  <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div className="w-full bg-gray-200 dark:bg-gray-600 rounded-full h-2">
                     <div
                       className="bg-primary-600 h-2 rounded-full transition-all duration-300"
                       style={{ width: `${uploadProgress}%` }}
@@ -260,7 +260,7 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
             </div>
 
             {/* Modal actions */}
-            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+            <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
               <button
                 type="submit"
                 disabled={isLoading || (!title || (!file && !imageUrl))}
@@ -279,7 +279,7 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({ onClose, onSuccess 
                 type="button"
                 onClick={onClose}
                 disabled={isLoading}
-                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
               >
                 Annuller
               </button>

--- a/src/components/InquiriesAdmin.tsx
+++ b/src/components/InquiriesAdmin.tsx
@@ -76,15 +76,15 @@ const InquiriesAdmin: React.FC = () => {
   const getStatusColor = (status: Inquiry['status']) => {
     switch (status) {
       case 'pending':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400'
       case 'confirmed':
-        return 'bg-green-100 text-green-800'
+        return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400'
       case 'declined':
-        return 'bg-red-100 text-red-800'
+        return 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400'
       case 'completed':
-        return 'bg-blue-100 text-blue-800'
+        return 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400'
       default:
-        return 'bg-gray-100 text-gray-800'
+        return 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
     }
   }
 
@@ -117,8 +117,8 @@ const InquiriesAdmin: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Forespørgsler</h2>
-            <p className="mt-1 text-sm text-gray-600">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Forespørgsler</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
               Administrer booking forespørgsler
             </p>
           </div>
@@ -126,29 +126,29 @@ const InquiriesAdmin: React.FC = () => {
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+        <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
           {error}
         </div>
       )}
 
       {/* Inquiries List */}
-      <div className="bg-white shadow overflow-hidden sm:rounded-md">
-        <ul className="divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-md">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {inquiries.length === 0 ? (
-            <li className="px-6 py-4 text-center text-gray-500">
+            <li className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">
               Ingen forespørgsler fundet
             </li>
           ) : (
             inquiries.map((inquiry) => (
-              <li key={inquiry.id} className="px-6 py-4 hover:bg-gray-50">
+              <li key={inquiry.id} className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700">
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-3">
                       <div>
-                        <p className="text-sm font-medium text-gray-900">
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">
                           {inquiry.name}
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           {inquiry.email}
                         </p>
                       </div>
@@ -157,7 +157,7 @@ const InquiriesAdmin: React.FC = () => {
                       </span>
                     </div>
                     
-                    <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-gray-500">
+                    <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-gray-500 dark:text-gray-400">
                       <div>
                         <span className="font-medium">Ankomst:</span>
                         <p>{new Date(inquiry.arrival_date).toLocaleDateString('da-DK')}</p>
@@ -178,13 +178,13 @@ const InquiriesAdmin: React.FC = () => {
                     
                     {inquiry.message && (
                       <div className="mt-2">
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
                           <span className="font-medium">Besked:</span> {inquiry.message}
                         </p>
                       </div>
                     )}
                     
-                    <div className="mt-2 text-xs text-gray-400">
+                    <div className="mt-2 text-xs text-gray-400 dark:text-gray-500">
                       Oprettet: {new Date(inquiry.created_at).toLocaleDateString('da-DK')}
                     </div>
                   </div>
@@ -193,7 +193,7 @@ const InquiriesAdmin: React.FC = () => {
                     <select
                       value={inquiry.status}
                       onChange={(e) => handleStatusUpdate(inquiry.id, e.target.value as Inquiry['status'])}
-                      className="text-sm border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                      className="text-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:ring-primary-500 focus:border-primary-500"
                     >
                       <option value="pending">Afventer</option>
                       <option value="confirmed">Bekræftet</option>

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -50,6 +50,15 @@ const LocationMap = ({
               <strong className="block font-semibold">{city}</strong>
               {address && <span className="text-sm">{address}</span>}
               {postalCode && <span className="text-sm block">{postalCode} {city}</span>}
+              <a
+                href="https://www.google.com/maps/search/?api=1&query=Mejerivej+3,+6771+Gredstedbro"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Åbn i Google Maps"
+                className="inline-block mt-2 text-xs text-blue-600 hover:text-blue-800 underline"
+              >
+                Åbn i Google Maps
+              </a>
             </div>
           </Popup>
         </Marker>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -47,10 +47,10 @@ const Login: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div>
-          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-primary-100">
+          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900/30">
             <svg
               className="h-8 w-8 text-primary-600"
               fill="none"
@@ -65,17 +65,17 @@ const Login: React.FC = () => {
               />
             </svg>
           </div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white">
             Admin Login
           </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
+          <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
             Log ind for at administrere galleriet
           </p>
         </div>
         
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+            <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
               {error}
             </div>
           )}
@@ -90,7 +90,7 @@ const Login: React.FC = () => {
                 name="username"
                 type="text"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white dark:bg-gray-700 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
                 placeholder="Brugernavn"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -106,7 +106,7 @@ const Login: React.FC = () => {
                 name="password"
                 type="password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white dark:bg-gray-700 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -133,17 +133,17 @@ const Login: React.FC = () => {
         <div className="mt-6">
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300" />
+              <div className="w-full border-t border-gray-300 dark:border-gray-600" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-gray-50 text-gray-500">eller</span>
+              <span className="px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400">eller</span>
             </div>
           </div>
 
           <div className="mt-6">
             <a
               href="/api/auth/github"
-              className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+              className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12" />


### PR DESCRIPTION
## Summary
- Admin-panel og login-side får fuld dark mode-styling, så de matcher resten af appen (som kører permanent i dark mode via `<html class="dark">`)
- Adresse i kontaktsektionen og kort-popup har nu klikbart "Åbn i Google Maps"-link der åbner i ny fane
- E2E-tests tilføjet for begge features (`e2e/admin-darkmode.spec.ts` og `e2e/contact-maps.spec.ts`)

## Ændrede komponenter
- `AdminLayout`, `Login`, `GalleryAdmin`, `InquiriesAdmin`, `ContactsAdmin`, `FacilitiesAdmin`, `ImageUploadModal`, `ImageEditModal` — `dark:`-klasser tilføjet
- `Contact`, `LocationMap` — Google Maps-link

## Test plan
- [ ] Verificér i Vercel preview at admin-panel ser mørkt ud (login-side, sidebar, alle 4 admin-undersider, modals)
- [ ] Klik "Åbn i Google Maps"-linket på kontaktsektionen og bekræft at det åbner Mejerivej 3 i ny fane
- [ ] Klik markøren på kortet og verificér at popup-linket virker
- [ ] E2E-tests kører grønt mod dev-databasen i preview-miljøet

🤖 Generated with [Claude Code](https://claude.com/claude-code)