### PR TITLE
feat: skjul GitHub-login på admin-login-siden

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -17,19 +17,6 @@ const Login: React.FC = () => {
     }
   }, [isAuthenticated, navigate])
 
-  // Show error from OAuth redirect URL parameter
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const urlError = params.get('error')
-    if (urlError === 'unauthorized') {
-      setError('Din GitHub-konto har ikke adgang til adminpanelet')
-      window.history.replaceState(null, '', window.location.pathname)
-    } else if (urlError) {
-      setError('GitHub-login fejlede — prøv igen')
-      window.history.replaceState(null, '', window.location.pathname)
-    }
-  }, [])
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -129,29 +116,6 @@ const Login: React.FC = () => {
             </button>
           </div>
         </form>
-
-        <div className="mt-6">
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300 dark:border-gray-600" />
-            </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400">eller</span>
-            </div>
-          </div>
-
-          <div className="mt-6">
-            <a
-              href="/api/auth/github"
-              className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-            >
-              <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12" />
-              </svg>
-              Log ind med GitHub
-            </a>
-          </div>
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Fjerner GitHub-login-knappen og "eller"-divider fra admin-login-siden
- Fjerner den tilhørende `useEffect` der parsede OAuth-fejl-parametre fra URL'en
- Backend-routerne (`/api/auth/github`) er bevaret urørt, så feature kan reaktiveres ved at genindsætte UI'et

## Test plan
- [ ] Åbn `/admin/login` i preview — kun Brugernavn, Password og "Log ind"-knap skal være synlige
- [ ] Verificer at normalt login med brugernavn/password stadig virker
- [ ] Bekræft at ingen "Log ind med GitHub"-knap eller "eller"-divider vises

🤖 Generated with [Claude Code](https://claude.com/claude-code)