### PR TITLE
fix: ret tastefejl i About-tekst

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -15,7 +15,7 @@ const About = () => {
               
               </p>
               <p>
-                Teltet kan slås mellem frugttræer og vilde bede og der er rig lejlighed til at nyde
+                Teltet kan slås op mellem frugttræer og vilde bede og der er rig lejlighed til at nyde
                  den skønne have med masser af siddepladser. Gæster er meget velkommen til at plukke af 
                  havens frugter, bær og smage på årstidens grøntsager. Shelter er placeret tilbagetrukken i haven.
               </p>


### PR DESCRIPTION
## Summary
- Tilføjet manglende "op" i sætningen om opslåning af telt i About-sektionen.

Før: "Teltet kan slås mellem frugttræer..."
Efter: "Teltet kan slås op mellem frugttræer..."

## Test plan
- [ ] Verificér at About-sektionen viser den rettede tekst i preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)