### PR TITLE
chore: ignorer .playwright-cli/ i git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ coverage/
 
 # Playwright MCP screenshots
 .playwright-mcp/
+.playwright-cli/
 
 # PRD filer (arbejdsdokumenter)
 PRD-*.md


### PR DESCRIPTION
## Summary

Tilføjer `.playwright-cli/` til `.gitignore` så de løbende browser-snapshots fra Playwright CLI ikke ender i repoet (samme behandling som `.playwright-mcp/` allerede har).

## Test plan
- [x] `git status` viser ikke længere `.playwright-cli/` som untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)