### PR TITLE
feat: tilgængelighedskalender med admin-styring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,11 @@ coverage/
 # TypeScript build info
 *.tsbuildinfo
 
-# Playwright MCP screenshots
+# Playwright
 .playwright-mcp/
 .playwright-cli/
+test-results/
+playwright-report/
 
 # PRD filer (arbejdsdokumenter)
 PRD-*.md

--- a/e2e/availability.spec.ts
+++ b/e2e/availability.spec.ts
@@ -101,5 +101,15 @@ test.describe('Tilgængelighedskalender', () => {
       const data = await (await request.get(`${API_URL}/availability`)).json();
       return data.data.season;
     }).toMatchObject({ season_start: '2027-05-01', season_end: '2027-09-30' });
+
+    // Ryd op: sæt sæsonen tilbage til standard, så den delte dev-database
+    // ikke efterlades med en 2027-sæson (beforeEach nulstiller kun før hver test).
+    const token = (await (await request.post(`${API_URL}/auth/login`, {
+      data: { username: 'admin', password: 'Susi2010' },
+    })).json()).data.token;
+    await request.put(`${API_URL}/availability/season`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { season_start: '2026-06-01', season_end: '2026-09-01' },
+    });
   });
 });

--- a/e2e/availability.spec.ts
+++ b/e2e/availability.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = 'http://localhost:3000/api';
+
+// Vælg en dato der altid er synlig i den aktuelle måned uden at navigere:
+// månedens sidste dag er altid >= i dag og dermed ikke "fortid".
+function seedDateISO(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const lastDay = new Date(y, m + 1, 0).getDate();
+  return `${y}-${String(m + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+}
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${API_URL}/test/reset`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test.describe('Tilgængelighedskalender', () => {
+  test('offentlig kalender viser en optaget dag og detaljer ved klik', async ({ page }) => {
+    const iso = seedDateISO();
+    const y = new Date().getFullYear();
+
+    // Mock API'et, så testen er deterministisk og uafhængig af den delte
+    // test-database (andre parallelle tests nulstiller den via /test/reset).
+    await page.route('**/api/availability', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            season: { season_start: `${y - 1}-01-01`, season_end: `${y + 1}-12-31` },
+            days: [{ date: iso, shelter_occupied: true, tents_occupied: 2 }],
+          },
+        }),
+      });
+    });
+
+    await page.goto('/');
+
+    // Dagen er synlig i den aktuelle måned (kalenderen åbner på indeværende måned)
+    const cell = page.locator(`#availability button[aria-label="${iso}"]`);
+    await expect(cell).toBeVisible();
+    // Delvist optaget → gul
+    await expect(cell).toHaveClass(/bg-yellow-100/);
+
+    // Klik viser detaljelinje med korrekt antal ledige teltpladser
+    await cell.click();
+    const detail = page.locator('#availability').getByText('Teltpladser: 1 af 3 ledige');
+    await expect(detail).toBeVisible();
+    await expect(page.locator('#availability').getByText('Shelter: optaget')).toBeVisible();
+  });
+
+  test('admin kan markere, lukke og nulstille en dag samt ændre sæson', async ({ page, request }) => {
+    const iso = seedDateISO();
+
+    // Log ind via UI
+    await page.goto('/admin/login');
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'Susi2010');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/admin/);
+
+    // Gå til kalenderen
+    await page.click('a[href="/admin/calendar"]');
+    await expect(page.getByRole('heading', { name: 'Kalender', level: 2 })).toBeVisible();
+
+    // Vælg dagen og markér shelter optaget + 2 teltpladser
+    await page.locator(`button[aria-label="${iso}"]`).click();
+    await page.getByRole('button', { name: 'Optaget', exact: true }).click();
+    await page.getByRole('button', { name: '2', exact: true }).click();
+
+    await expect.poll(async () => {
+      const data = await (await request.get(`${API_URL}/availability`)).json();
+      return data.data.days.find((d: { date: string }) => d.date === iso) ?? null;
+    }).toMatchObject({ shelter_occupied: true, tents_occupied: 2 });
+
+    // Luk hele dagen → shelter optaget + 3 teltpladser
+    await page.getByRole('button', { name: 'Luk hele dagen' }).click();
+    await expect.poll(async () => {
+      const data = await (await request.get(`${API_URL}/availability`)).json();
+      return data.data.days.find((d: { date: string }) => d.date === iso) ?? null;
+    }).toMatchObject({ shelter_occupied: true, tents_occupied: 3 });
+
+    // Nulstil til ledig → rækken fjernes (sparsom lagring)
+    await page.getByRole('button', { name: 'Nulstil til ledig' }).click();
+    await expect.poll(async () => {
+      const data = await (await request.get(`${API_URL}/availability`)).json();
+      return data.data.days.some((d: { date: string }) => d.date === iso);
+    }).toBe(false);
+
+    // Ændr sæson via formen
+    await page.fill('#season-start', '2027-05-01');
+    await page.fill('#season-end', '2027-09-30');
+    await page.getByRole('button', { name: 'Gem sæson' }).click();
+    await expect(page.getByText('Gemt ✓')).toBeVisible();
+
+    await expect.poll(async () => {
+      const data = await (await request.get(`${API_URL}/availability`)).json();
+      return data.data.season;
+    }).toMatchObject({ season_start: '2027-05-01', season_end: '2027-09-30' });
+  });
+});

--- a/server/controllers/availabilityController.ts
+++ b/server/controllers/availabilityController.ts
@@ -1,0 +1,86 @@
+import { Request, Response } from 'express';
+import { availabilityRepository } from '../repositories/availabilityRepository';
+import { upsertAvailabilitySchema, updateSeasonSchema } from '../types';
+import { logger } from '../config/logger';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export class AvailabilityController {
+  /**
+   * GET /api/availability (public)
+   * Returns season config + all occupied days. The client computes per-day status.
+   */
+  async getAvailability(_req: Request, res: Response): Promise<void> {
+    try {
+      const [season, days] = await Promise.all([
+        availabilityRepository.getSeason(),
+        availabilityRepository.getOccupiedDays(),
+      ]);
+      res.status(200).json({ success: true, data: { season, days } });
+    } catch (error) {
+      logger.error('Error fetching availability', { error: (error as Error).message });
+      res.status(500).json({ success: false, message: 'Kunne ikke hente tilgængelighed' });
+    }
+  }
+
+  /**
+   * PUT /api/availability/season (admin)
+   */
+  async updateSeason(req: Request, res: Response): Promise<void> {
+    try {
+      const parsed = updateSeasonSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, message: parsed.error.errors[0]?.message ?? 'Ugyldige sæsondatoer' });
+        return;
+      }
+      const season = await availabilityRepository.updateSeason(parsed.data.season_start, parsed.data.season_end);
+      res.status(200).json({ success: true, data: season });
+    } catch (error) {
+      logger.error('Error updating season', { error: (error as Error).message });
+      res.status(500).json({ success: false, message: 'Kunne ikke opdatere sæson' });
+    }
+  }
+
+  /**
+   * PUT /api/availability/:date (admin)
+   */
+  async upsertDay(req: Request, res: Response): Promise<void> {
+    try {
+      const { date } = req.params;
+      if (!DATE_RE.test(date)) {
+        res.status(400).json({ success: false, message: 'Ugyldig dato' });
+        return;
+      }
+      const parsed = upsertAvailabilitySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, message: parsed.error.errors[0]?.message ?? 'Ugyldige data' });
+        return;
+      }
+      const day = await availabilityRepository.upsertDay(date, parsed.data.shelter_occupied, parsed.data.tents_occupied);
+      res.status(200).json({ success: true, data: day });
+    } catch (error) {
+      logger.error('Error updating availability', { error: (error as Error).message });
+      res.status(500).json({ success: false, message: 'Kunne ikke opdatere dagen' });
+    }
+  }
+
+  /**
+   * DELETE /api/availability/:date (admin) — nulstil til alt ledigt.
+   */
+  async resetDay(req: Request, res: Response): Promise<void> {
+    try {
+      const { date } = req.params;
+      if (!DATE_RE.test(date)) {
+        res.status(400).json({ success: false, message: 'Ugyldig dato' });
+        return;
+      }
+      await availabilityRepository.deleteDay(date);
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('Error resetting availability', { error: (error as Error).message });
+      res.status(500).json({ success: false, message: 'Kunne ikke nulstille dagen' });
+    }
+  }
+}
+
+export const availabilityController = new AvailabilityController();

--- a/server/db/schema.postgres.sql
+++ b/server/db/schema.postgres.sql
@@ -121,3 +121,25 @@ ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS show_in_hero BOOLEAN DEFAULT
 CREATE UNIQUE INDEX IF NOT EXISTS idx_gallery_images_url_unique ON gallery_images(image_url);
 
 -- No sample gallery images — all images are managed via the admin panel
+
+-- Availability Table
+-- Sparse: kun dage der afviger fra "alt ledigt" gemmes. Ingen række = alt ledigt.
+CREATE TABLE IF NOT EXISTS availability (
+    date DATE PRIMARY KEY,
+    shelter_occupied BOOLEAN NOT NULL DEFAULT false,
+    tents_occupied INTEGER NOT NULL DEFAULT 0 CHECK (tents_occupied >= 0 AND tents_occupied <= 3),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Season Config Table (singleton-række med id = 1)
+CREATE TABLE IF NOT EXISTS season_config (
+    id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    season_start DATE NOT NULL,
+    season_end DATE NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Seed default season (1. juni – 1. september 2026), kun hvis tabellen er tom.
+INSERT INTO season_config (id, season_start, season_end)
+VALUES (1, '2026-06-01', '2026-09-01')
+ON CONFLICT (id) DO NOTHING;

--- a/server/repositories/availabilityRepository.ts
+++ b/server/repositories/availabilityRepository.ts
@@ -1,0 +1,77 @@
+import { query, queryOne, execute } from '../db/database.postgres';
+import { Availability, SeasonConfig } from '../types';
+
+const DEFAULT_SEASON: SeasonConfig = {
+  season_start: '2026-06-01',
+  season_end: '2026-09-01',
+};
+
+export class AvailabilityRepository {
+  /**
+   * Get the (single) season configuration. Dates returned as YYYY-MM-DD
+   * strings via to_char to avoid timezone-skewed Date parsing.
+   */
+  async getSeason(): Promise<SeasonConfig> {
+    const row = await queryOne<SeasonConfig>(
+      `SELECT to_char(season_start, 'YYYY-MM-DD') AS season_start,
+              to_char(season_end, 'YYYY-MM-DD') AS season_end
+       FROM season_config WHERE id = 1`
+    );
+    return row ?? DEFAULT_SEASON;
+  }
+
+  async updateSeason(seasonStart: string, seasonEnd: string): Promise<SeasonConfig> {
+    await execute(
+      `INSERT INTO season_config (id, season_start, season_end, updated_at)
+       VALUES (1, $1, $2, CURRENT_TIMESTAMP)
+       ON CONFLICT (id) DO UPDATE
+         SET season_start = EXCLUDED.season_start,
+             season_end = EXCLUDED.season_end,
+             updated_at = CURRENT_TIMESTAMP`,
+      [seasonStart, seasonEnd]
+    );
+    return this.getSeason();
+  }
+
+  /**
+   * Only returns days that differ from the default (something occupied).
+   */
+  async getOccupiedDays(): Promise<Availability[]> {
+    return query<Availability>(
+      `SELECT to_char(date, 'YYYY-MM-DD') AS date, shelter_occupied, tents_occupied
+       FROM availability
+       WHERE shelter_occupied = true OR tents_occupied > 0
+       ORDER BY date ASC`
+    );
+  }
+
+  /**
+   * Upsert a day. If the day ends up fully free, the row is deleted to keep
+   * the table sparse.
+   */
+  async upsertDay(date: string, shelterOccupied: boolean, tentsOccupied: number): Promise<Availability> {
+    if (!shelterOccupied && tentsOccupied === 0) {
+      await this.deleteDay(date);
+      return { date, shelter_occupied: false, tents_occupied: 0 };
+    }
+
+    await execute(
+      `INSERT INTO availability (date, shelter_occupied, tents_occupied, updated_at)
+       VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+       ON CONFLICT (date) DO UPDATE
+         SET shelter_occupied = EXCLUDED.shelter_occupied,
+             tents_occupied = EXCLUDED.tents_occupied,
+             updated_at = CURRENT_TIMESTAMP`,
+      [date, shelterOccupied, tentsOccupied]
+    );
+
+    return { date, shelter_occupied: shelterOccupied, tents_occupied: tentsOccupied };
+  }
+
+  async deleteDay(date: string): Promise<boolean> {
+    const result = await execute('DELETE FROM availability WHERE date = $1', [date]);
+    return result.rowCount > 0;
+  }
+}
+
+export const availabilityRepository = new AvailabilityRepository();

--- a/server/routes/availabilityRoutes.ts
+++ b/server/routes/availabilityRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { availabilityController } from '../controllers/availabilityController';
+import { authenticateToken } from '../middleware/auth';
+
+const router = Router();
+
+// Public endpoint
+router.get('/', availabilityController.getAvailability.bind(availabilityController));
+
+// Admin endpoints (protected). /season MUST be before /:date.
+router.put('/season', authenticateToken, availabilityController.updateSeason.bind(availabilityController));
+router.put('/:date', authenticateToken, availabilityController.upsertDay.bind(availabilityController));
+router.delete('/:date', authenticateToken, availabilityController.resetDay.bind(availabilityController));
+
+export default router;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import contactRoutes from './contactRoutes';
 import galleryRoutes from './galleryRoutes';
 import authRoutes from './authRoutes';
 import facilityRoutes from './facilityRoutes';
+import availabilityRoutes from './availabilityRoutes';
 import testRoutes from './testRoutes';
 
 const router = Router();
@@ -23,6 +24,7 @@ router.use('/contacts', contactRoutes);
 router.use('/gallery', galleryRoutes);
 router.use('/auth', authRoutes);
 router.use('/facilities', facilityRoutes);
+router.use('/availability', availabilityRoutes);
 router.use('/test', testRoutes);
 
 export default router;

--- a/server/routes/testRoutes.ts
+++ b/server/routes/testRoutes.ts
@@ -22,6 +22,16 @@ router.post('/reset', async (_req: Request, res: Response) => {
     await execute('DELETE FROM contacts');
     await execute('DELETE FROM gallery_images');
     await execute('DELETE FROM facilities');
+    await execute('DELETE FROM availability');
+
+    // Reset season config to default season (1. juni – 1. september 2026)
+    await execute(
+      `INSERT INTO season_config (id, season_start, season_end)
+       VALUES (1, '2026-06-01', '2026-09-01')
+       ON CONFLICT (id) DO UPDATE
+         SET season_start = EXCLUDED.season_start,
+             season_end = EXCLUDED.season_end`
+    );
 
     // Re-seed admin user
     await execute(

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -148,6 +148,36 @@ export interface UpdateFacilityInput {
   sort_order?: number;
 }
 
+// Availability / calendar types
+export interface Availability {
+  date: string;
+  shelter_occupied: boolean;
+  tents_occupied: number;
+}
+
+export interface SeasonConfig {
+  season_start: string;
+  season_end: string;
+}
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ugyldigt datoformat (forventede YYYY-MM-DD)');
+
+export const upsertAvailabilitySchema = z.object({
+  shelter_occupied: z.boolean(),
+  tents_occupied: z.number().int().min(0, 'Mindst 0 teltpladser').max(3, 'Max 3 teltpladser'),
+});
+
+export const updateSeasonSchema = z.object({
+  season_start: isoDate,
+  season_end: isoDate,
+}).refine((data) => data.season_end >= data.season_start, {
+  message: 'Slutdato skal være samme dag eller efter startdato',
+  path: ['season_end'],
+});
+
+export type UpsertAvailabilityInput = z.infer<typeof upsertAvailabilitySchema>;
+export type UpdateSeasonInput = z.infer<typeof updateSeasonSchema>;
+
 export interface AuthResponse {
   success: boolean;
   token: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,14 @@ import GalleryAdmin from './components/GalleryAdmin'
 import InquiriesAdmin from './components/InquiriesAdmin'
 import ContactsAdmin from './components/ContactsAdmin'
 import FacilitiesAdmin from './components/FacilitiesAdmin'
+import CalendarAdmin from './components/CalendarAdmin'
 import Header from './components/Header'
 import Hero from './components/Hero'
 import About from './components/About'
 import Facilities from './components/Facilities'
 import Gallery from './components/Gallery'
 import Pricing from './components/Pricing'
+import Availability from './components/Availability'
 import Contact from './components/Contact'
 import Footer from './components/Footer'
 
@@ -54,6 +56,7 @@ const PublicApp: React.FC = () => {
         <Facilities />
         <Gallery />
         <Pricing />
+        <Availability />
         <Contact />
       </main>
       <Footer />
@@ -71,6 +74,7 @@ const AdminRoutes: React.FC = () => {
         <Route path="/inquiries" element={<InquiriesAdmin />} />
         <Route path="/contacts" element={<ContactsAdmin />} />
         <Route path="/facilities" element={<FacilitiesAdmin />} />
+        <Route path="/calendar" element={<CalendarAdmin />} />
         <Route path="*" element={<Navigate to="/admin/gallery" replace />} />
       </Routes>
     </AdminLayout>

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -47,9 +47,9 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
             </Link>
             
             <Link
-              to="/admin/inquiries"
+              to="/admin/calendar"
               className={`flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-                isActive('/admin/inquiries')
+                isActive('/admin/calendar')
                   ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
                   : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
               }`}
@@ -64,10 +64,10 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                 />
               </svg>
-              Forespørgsler
+              Kalender
             </Link>
             
             <Link
@@ -166,7 +166,7 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
               <div className="flex items-center">
                 <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
                   {isActive('/admin') && 'Galleri Administration'}
-                  {isActive('/admin/inquiries') && 'Forespørgsler'}
+                  {isActive('/admin/calendar') && 'Kalender'}
                   {isActive('/admin/contacts') && 'Kontaktbeskeder'}
                   {isActive('/admin/facilities') && 'Faciliteter Administration'}
                 </h1>

--- a/src/components/Availability.tsx
+++ b/src/components/Availability.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useMemo } from 'react'
+import { API_URL } from '../config/api'
+import CalendarGrid from './CalendarGrid'
+import CalendarLegend from './CalendarLegend'
+import {
+  computeStatus,
+  dayDetail,
+  formatLongDate,
+  statusLabel,
+  todayISO,
+  type OccupiedDay,
+  type SeasonConfig,
+} from '../utils/availability'
+
+const DEFAULT_SEASON: SeasonConfig = { season_start: '2026-06-01', season_end: '2026-09-01' }
+
+const Availability = () => {
+  const [season, setSeason] = useState<SeasonConfig>(DEFAULT_SEASON)
+  const [occupiedDays, setOccupiedDays] = useState<OccupiedDay[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const now = new Date()
+  const [viewYear, setViewYear] = useState(now.getFullYear())
+  const [viewMonth, setViewMonth] = useState(now.getMonth())
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchAvailability = async () => {
+      try {
+        const response = await fetch(`${API_URL}/availability`)
+        if (!response.ok) throw new Error('Failed to fetch availability')
+        const data = await response.json()
+        setSeason(data.data?.season ?? DEFAULT_SEASON)
+        setOccupiedDays(data.data?.days ?? [])
+      } catch (err) {
+        console.error('Error fetching availability:', err)
+        setError('Kunne ikke hente kalenderen lige nu')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchAvailability()
+  }, [])
+
+  const occupiedByDate = useMemo(() => {
+    const map: Record<string, OccupiedDay> = {}
+    for (const day of occupiedDays) map[day.date] = day
+    return map
+  }, [occupiedDays])
+
+  const goToPrevMonth = () => {
+    setViewMonth((m) => {
+      if (m === 0) { setViewYear((y) => y - 1); return 11 }
+      return m - 1
+    })
+  }
+  const goToNextMonth = () => {
+    setViewMonth((m) => {
+      if (m === 11) { setViewYear((y) => y + 1); return 0 }
+      return m + 1
+    })
+  }
+
+  const selectedStatus = selectedDate
+    ? computeStatus(selectedDate, occupiedByDate[selectedDate], season, todayISO())
+    : null
+
+  return (
+    <section id="availability" className="bg-white dark:bg-gray-900 transition-colors">
+      <div className="section-container">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">Ledige dage</h2>
+          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            Se hvilke dage der er ledige i sæsonen. Tryk på en dag for at se shelter og teltpladser.
+          </p>
+        </div>
+
+        <div className="max-w-2xl mx-auto">
+          <div className="card p-6 sm:p-8">
+            {isLoading ? (
+              <div className="flex items-center justify-center h-64">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+              </div>
+            ) : error ? (
+              <div className="text-center text-gray-600 dark:text-gray-300 py-8">{error}</div>
+            ) : (
+              <>
+                <div className="mb-6">
+                  <CalendarLegend />
+                </div>
+
+                <CalendarGrid
+                  year={viewYear}
+                  month={viewMonth}
+                  onPrevMonth={goToPrevMonth}
+                  onNextMonth={goToNextMonth}
+                  occupiedByDate={occupiedByDate}
+                  season={season}
+                  selectedDate={selectedDate}
+                  onSelectDate={setSelectedDate}
+                />
+
+                {/* Detalje for valgt dag */}
+                <div className="mt-6 min-h-[4rem] rounded-lg bg-gray-50 dark:bg-gray-800 p-4">
+                  {selectedDate && selectedStatus ? (
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white capitalize">
+                        {formatLongDate(selectedDate)} — {statusLabel(selectedStatus)}
+                      </p>
+                      <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                        {dayDetail(selectedStatus, occupiedByDate[selectedDate])}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
+                      Tryk på en dag for at se ledige pladser.
+                    </p>
+                  )}
+                </div>
+
+                <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-300">
+                  Ser du en ledig dag?{' '}
+                  <a href="#contact" className="text-primary-600 dark:text-primary-400 font-medium hover:underline">
+                    Kontakt Elin for at booke
+                  </a>
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Availability

--- a/src/components/Availability.tsx
+++ b/src/components/Availability.tsx
@@ -49,17 +49,10 @@ const Availability = () => {
     return map
   }, [occupiedDays])
 
-  const goToPrevMonth = () => {
-    setViewMonth((m) => {
-      if (m === 0) { setViewYear((y) => y - 1); return 11 }
-      return m - 1
-    })
-  }
-  const goToNextMonth = () => {
-    setViewMonth((m) => {
-      if (m === 11) { setViewYear((y) => y + 1); return 0 }
-      return m + 1
-    })
+  const shiftMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1)
+    setViewYear(d.getFullYear())
+    setViewMonth(d.getMonth())
   }
 
   const selectedStatus = selectedDate
@@ -93,8 +86,8 @@ const Availability = () => {
                 <CalendarGrid
                   year={viewYear}
                   month={viewMonth}
-                  onPrevMonth={goToPrevMonth}
-                  onNextMonth={goToNextMonth}
+                  onPrevMonth={() => shiftMonth(-1)}
+                  onNextMonth={() => shiftMonth(1)}
                   occupiedByDate={occupiedByDate}
                   season={season}
                   selectedDate={selectedDate}

--- a/src/components/CalendarAdmin.tsx
+++ b/src/components/CalendarAdmin.tsx
@@ -65,11 +65,10 @@ const CalendarAdmin: React.FC = () => {
     ? occupiedByDate[selectedDate] ?? { date: selectedDate, shelter_occupied: false, tents_occupied: 0 }
     : { date: '', shelter_occupied: false, tents_occupied: 0 }
 
-  const goToPrevMonth = () => {
-    setViewMonth((m) => { if (m === 0) { setViewYear((y) => y - 1); return 11 } return m - 1 })
-  }
-  const goToNextMonth = () => {
-    setViewMonth((m) => { if (m === 11) { setViewYear((y) => y + 1); return 0 } return m + 1 })
+  const shiftMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1)
+    setViewYear(d.getFullYear())
+    setViewMonth(d.getMonth())
   }
 
   // Opdatér lokal state efter et gemt kald
@@ -208,8 +207,8 @@ const CalendarAdmin: React.FC = () => {
         <CalendarGrid
           year={viewYear}
           month={viewMonth}
-          onPrevMonth={goToPrevMonth}
-          onNextMonth={goToNextMonth}
+          onPrevMonth={() => shiftMonth(-1)}
+          onNextMonth={() => shiftMonth(1)}
           occupiedByDate={occupiedByDate}
           season={season}
           selectedDate={selectedDate}

--- a/src/components/CalendarAdmin.tsx
+++ b/src/components/CalendarAdmin.tsx
@@ -1,0 +1,310 @@
+import React, { useState, useEffect, useMemo } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { API_URL } from '../config/api'
+import CalendarGrid from './CalendarGrid'
+import CalendarLegend from './CalendarLegend'
+import {
+  computeStatus,
+  formatLongDate,
+  statusLabel,
+  todayISO,
+  TOTAL_TENTS,
+  type OccupiedDay,
+  type SeasonConfig,
+} from '../utils/availability'
+
+const DEFAULT_SEASON: SeasonConfig = { season_start: '2026-06-01', season_end: '2026-09-01' }
+
+const CalendarAdmin: React.FC = () => {
+  const { token } = useAuth()
+  const [season, setSeason] = useState<SeasonConfig>(DEFAULT_SEASON)
+  const [occupiedDays, setOccupiedDays] = useState<OccupiedDay[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const now = new Date()
+  const [viewYear, setViewYear] = useState(now.getFullYear())
+  const [viewMonth, setViewMonth] = useState(now.getMonth())
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+
+  // Sæson-form
+  const [seasonStart, setSeasonStart] = useState(DEFAULT_SEASON.season_start)
+  const [seasonEnd, setSeasonEnd] = useState(DEFAULT_SEASON.season_end)
+  const [isSavingSeason, setIsSavingSeason] = useState(false)
+  const [seasonSaved, setSeasonSaved] = useState(false)
+
+  useEffect(() => {
+    fetchAvailability()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const fetchAvailability = async () => {
+    try {
+      const response = await fetch(`${API_URL}/availability`)
+      if (!response.ok) throw new Error('Failed to fetch')
+      const data = await response.json()
+      const s: SeasonConfig = data.data?.season ?? DEFAULT_SEASON
+      setSeason(s)
+      setSeasonStart(s.season_start)
+      setSeasonEnd(s.season_end)
+      setOccupiedDays(data.data?.days ?? [])
+    } catch {
+      setError('Kunne ikke hente kalenderen')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const occupiedByDate = useMemo(() => {
+    const map: Record<string, OccupiedDay> = {}
+    for (const day of occupiedDays) map[day.date] = day
+    return map
+  }, [occupiedDays])
+
+  const selectedDay: OccupiedDay = selectedDate
+    ? occupiedByDate[selectedDate] ?? { date: selectedDate, shelter_occupied: false, tents_occupied: 0 }
+    : { date: '', shelter_occupied: false, tents_occupied: 0 }
+
+  const goToPrevMonth = () => {
+    setViewMonth((m) => { if (m === 0) { setViewYear((y) => y - 1); return 11 } return m - 1 })
+  }
+  const goToNextMonth = () => {
+    setViewMonth((m) => { if (m === 11) { setViewYear((y) => y + 1); return 0 } return m + 1 })
+  }
+
+  // Opdatér lokal state efter et gemt kald
+  const applyLocal = (date: string, shelter: boolean, tents: number) => {
+    setOccupiedDays((prev) => {
+      const rest = prev.filter((d) => d.date !== date)
+      if (!shelter && tents === 0) return rest // fuldt ledigt → fjern række
+      return [...rest, { date, shelter_occupied: shelter, tents_occupied: tents }]
+    })
+  }
+
+  const saveDay = async (date: string, shelter: boolean, tents: number) => {
+    applyLocal(date, shelter, tents) // optimistisk
+    try {
+      const response = await fetch(`${API_URL}/availability/${date}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ shelter_occupied: shelter, tents_occupied: tents }),
+      })
+      if (!response.ok) throw new Error('Failed to save day')
+    } catch {
+      setError('Kunne ikke gemme dagen')
+      fetchAvailability()
+    }
+  }
+
+  const resetDay = async (date: string) => {
+    applyLocal(date, false, 0)
+    try {
+      const response = await fetch(`${API_URL}/availability/${date}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` },
+      })
+      if (!response.ok) throw new Error('Failed to reset day')
+    } catch {
+      setError('Kunne ikke nulstille dagen')
+      fetchAvailability()
+    }
+  }
+
+  const saveSeason = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSavingSeason(true)
+    setSeasonSaved(false)
+    setError('')
+    try {
+      const response = await fetch(`${API_URL}/availability/season`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ season_start: seasonStart, season_end: seasonEnd }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        throw new Error(data?.message ?? 'Failed to save season')
+      }
+      const data = await response.json()
+      setSeason(data.data)
+      setSeasonSaved(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunne ikke gemme sæson')
+    } finally {
+      setIsSavingSeason(false)
+    }
+  }
+
+  const selectedStatus = selectedDate
+    ? computeStatus(selectedDate, occupiedByDate[selectedDate], season, todayISO())
+    : null
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Kalender</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Marker hvilke dage shelteret og teltpladserne er optaget. Urørte dage er ledige.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-400 px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
+
+      {/* Sæson-form */}
+      <div className="bg-white dark:bg-gray-800 shadow sm:rounded-md p-6 mb-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Sæson</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Dage uden for sæsonen vises som lukkede for gæsterne.
+        </p>
+        <form onSubmit={saveSeason} className="flex flex-wrap items-end gap-4">
+          <div>
+            <label htmlFor="season-start" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Start</label>
+            <input
+              id="season-start"
+              type="date"
+              value={seasonStart}
+              onChange={(e) => { setSeasonStart(e.target.value); setSeasonSaved(false) }}
+              className="border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="season-end" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slut</label>
+            <input
+              id="season-end"
+              type="date"
+              value={seasonEnd}
+              onChange={(e) => { setSeasonEnd(e.target.value); setSeasonSaved(false) }}
+              className="border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={isSavingSeason}
+            className="px-4 py-2 text-sm font-medium text-white bg-primary-600 border border-transparent rounded-md hover:bg-primary-700 disabled:opacity-50"
+          >
+            {isSavingSeason ? 'Gemmer...' : 'Gem sæson'}
+          </button>
+          {seasonSaved && <span className="text-sm text-green-600 dark:text-green-400">Gemt ✓</span>}
+        </form>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 shadow sm:rounded-md p-6 max-w-2xl">
+        <div className="mb-6">
+          <CalendarLegend />
+        </div>
+
+        <CalendarGrid
+          year={viewYear}
+          month={viewMonth}
+          onPrevMonth={goToPrevMonth}
+          onNextMonth={goToNextMonth}
+          occupiedByDate={occupiedByDate}
+          season={season}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+        />
+
+        {/* Redigeringsboks for valgt dag */}
+        <div className="mt-6 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          {selectedDate && selectedStatus ? (
+            <div>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white capitalize mb-4">
+                {formatLongDate(selectedDate)} — {statusLabel(selectedStatus)}
+              </p>
+
+              {/* Shelter */}
+              <div className="mb-4">
+                <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Shelter</span>
+                <div className="inline-flex rounded-md shadow-sm" role="group">
+                  <button
+                    type="button"
+                    onClick={() => saveDay(selectedDate, false, selectedDay.tents_occupied)}
+                    className={`px-4 py-2 text-sm font-medium rounded-l-md border ${
+                      !selectedDay.shelter_occupied
+                        ? 'bg-green-600 text-white border-green-600'
+                        : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600'
+                    }`}
+                  >
+                    Ledig
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => saveDay(selectedDate, true, selectedDay.tents_occupied)}
+                    className={`px-4 py-2 text-sm font-medium rounded-r-md border -ml-px ${
+                      selectedDay.shelter_occupied
+                        ? 'bg-red-600 text-white border-red-600'
+                        : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600'
+                    }`}
+                  >
+                    Optaget
+                  </button>
+                </div>
+              </div>
+
+              {/* Teltpladser */}
+              <div className="mb-4">
+                <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Teltpladser optaget (af {TOTAL_TENTS})
+                </span>
+                <div className="inline-flex rounded-md shadow-sm" role="group">
+                  {[0, 1, 2, 3].map((n, i) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => saveDay(selectedDate, selectedDay.shelter_occupied, n)}
+                      className={`px-4 py-2 text-sm font-medium border ${i === 0 ? 'rounded-l-md' : '-ml-px'} ${
+                        i === 3 ? 'rounded-r-md' : ''
+                      } ${
+                        selectedDay.tents_occupied === n
+                          ? 'bg-primary-600 text-white border-primary-600'
+                          : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600'
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Genveje */}
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={() => saveDay(selectedDate, true, TOTAL_TENTS)}
+                  className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700"
+                >
+                  Luk hele dagen
+                </button>
+                <button
+                  type="button"
+                  onClick={() => resetDay(selectedDate)}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600"
+                >
+                  Nulstil til ledig
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
+              Vælg en dag i kalenderen for at redigere den.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CalendarAdmin

--- a/src/components/CalendarGrid.tsx
+++ b/src/components/CalendarGrid.tsx
@@ -1,0 +1,106 @@
+import {
+  buildMonthGrid,
+  computeStatus,
+  formatMonthTitle,
+  parseISODate,
+  todayISO,
+  WEEKDAY_LABELS,
+  type DayStatus,
+  type OccupiedDay,
+  type SeasonConfig,
+} from '../utils/availability'
+
+interface CalendarGridProps {
+  year: number
+  month: number
+  onPrevMonth: () => void
+  onNextMonth: () => void
+  occupiedByDate: Record<string, OccupiedDay>
+  season: SeasonConfig
+  selectedDate: string | null
+  onSelectDate: (iso: string) => void
+}
+
+const STATUS_CELL_CLASSES: Record<DayStatus, string> = {
+  available: 'bg-green-100 dark:bg-green-900/40 text-green-900 dark:text-green-200 hover:bg-green-200 dark:hover:bg-green-900/60',
+  partial: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-900 dark:text-yellow-200 hover:bg-yellow-200 dark:hover:bg-yellow-900/60',
+  full: 'bg-red-100 dark:bg-red-900/40 text-red-900 dark:text-red-200 hover:bg-red-200 dark:hover:bg-red-900/60',
+  'out-of-season': 'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700',
+  past: 'bg-gray-50 dark:bg-gray-800/50 text-gray-300 dark:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700/50',
+}
+
+const CalendarGrid: React.FC<CalendarGridProps> = ({
+  year,
+  month,
+  onPrevMonth,
+  onNextMonth,
+  occupiedByDate,
+  season,
+  selectedDate,
+  onSelectDate,
+}) => {
+  const today = todayISO()
+  const cells = buildMonthGrid(year, month)
+
+  return (
+    <div>
+      {/* Måneds-navigation */}
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={onPrevMonth}
+          aria-label="Forrige måned"
+          className="p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white capitalize">
+          {formatMonthTitle(year, month)}
+        </h3>
+        <button
+          onClick={onNextMonth}
+          aria-label="Næste måned"
+          className="p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Ugedage */}
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {WEEKDAY_LABELS.map((label) => (
+          <div key={label} className="text-center text-xs font-medium text-gray-500 dark:text-gray-400 py-1">
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Dage */}
+      <div className="grid grid-cols-7 gap-1">
+        {cells.map((iso, idx) => {
+          if (iso === null) return <div key={`empty-${idx}`} />
+          const status = computeStatus(iso, occupiedByDate[iso], season, today)
+          const dayNumber = parseISODate(iso).getDate()
+          const isSelected = iso === selectedDate
+          return (
+            <button
+              key={iso}
+              onClick={() => onSelectDate(iso)}
+              aria-label={iso}
+              className={`aspect-square rounded-md text-sm font-medium flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 ${
+                STATUS_CELL_CLASSES[status]
+              } ${isSelected ? 'ring-2 ring-primary-600 dark:ring-primary-400' : ''}`}
+            >
+              {dayNumber}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default CalendarGrid

--- a/src/components/CalendarLegend.tsx
+++ b/src/components/CalendarLegend.tsx
@@ -1,0 +1,19 @@
+const LEGEND_ITEMS: { color: string; label: string }[] = [
+  { color: 'bg-green-400 dark:bg-green-600', label: 'Alt ledigt' },
+  { color: 'bg-yellow-400 dark:bg-yellow-600', label: 'Delvist ledigt' },
+  { color: 'bg-red-400 dark:bg-red-600', label: 'Alt optaget' },
+  { color: 'bg-gray-300 dark:bg-gray-600', label: 'Uden for sæson' },
+]
+
+const CalendarLegend: React.FC = () => (
+  <div className="flex flex-wrap justify-center gap-x-4 gap-y-2">
+    {LEGEND_ITEMS.map((item) => (
+      <div key={item.label} className="flex items-center gap-1.5">
+        <span className={`inline-block w-3 h-3 rounded-sm ${item.color}`} />
+        <span className="text-xs text-gray-600 dark:text-gray-300">{item.label}</span>
+      </div>
+    ))}
+  </div>
+)
+
+export default CalendarLegend

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ const Header = ({ currentSection, setCurrentSection }: HeaderProps) => {
     { id: 'facilities', label: 'Faciliteter', href: '#facilities' },
     { id: 'gallery', label: 'Galleri', href: '#gallery' },
     { id: 'pricing', label: 'Priser', href: '#pricing' },
+    { id: 'availability', label: 'Ledige dage', href: '#availability' },
     { id: 'contact', label: 'Kontakt', href: '#contact' },
   ]
 

--- a/src/utils/availability.ts
+++ b/src/utils/availability.ts
@@ -1,0 +1,110 @@
+// Delt logik for tilgængelighedskalenderen (offentlig + admin).
+// Alle datoer håndteres som rene YYYY-MM-DD-strenge for at undgå tidszone-skæve datoer.
+
+export type DayStatus = 'available' | 'partial' | 'full' | 'out-of-season' | 'past'
+
+export interface OccupiedDay {
+  date: string
+  shelter_occupied: boolean
+  tents_occupied: number
+}
+
+export interface SeasonConfig {
+  season_start: string
+  season_end: string
+}
+
+export const TOTAL_TENTS = 3
+
+/** Formatér et Date-objekt til lokal YYYY-MM-DD (ingen UTC-konvertering). */
+export function toISODate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** Dagens dato som YYYY-MM-DD i lokal tid. */
+export function todayISO(): string {
+  return toISODate(new Date())
+}
+
+/** Parse YYYY-MM-DD til et lokalt Date-objekt (ingen tidszone-forskydning). */
+export function parseISODate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+/**
+ * Beregn status for en dag.
+ * Fortid prioriteres, derefter uden for sæson, derefter optaget-niveau.
+ */
+export function computeStatus(
+  dateISO: string,
+  occupied: OccupiedDay | undefined,
+  season: SeasonConfig,
+  today: string,
+): DayStatus {
+  if (dateISO < today) return 'past'
+  if (dateISO < season.season_start || dateISO > season.season_end) return 'out-of-season'
+
+  const shelter = occupied?.shelter_occupied ?? false
+  const tents = occupied?.tents_occupied ?? 0
+
+  if (!shelter && tents === 0) return 'available'
+  if (shelter && tents >= TOTAL_TENTS) return 'full'
+  return 'partial'
+}
+
+export function statusLabel(status: DayStatus): string {
+  switch (status) {
+    case 'available': return 'Alt ledigt'
+    case 'partial': return 'Delvist ledigt'
+    case 'full': return 'Alt optaget'
+    case 'out-of-season': return 'Uden for sæson'
+    case 'past': return 'Overstået'
+  }
+}
+
+/** Detaljelinje vist når en dag vælges, fx "Shelter: optaget · Teltpladser: 2 af 3 ledige". */
+export function dayDetail(status: DayStatus, occupied: OccupiedDay | undefined): string {
+  if (status === 'out-of-season') return 'Uden for sæson — ikke til booking'
+  if (status === 'past') return 'Datoen er overstået'
+
+  const shelter = occupied?.shelter_occupied ?? false
+  const tents = occupied?.tents_occupied ?? 0
+  const tentsFree = TOTAL_TENTS - tents
+  const shelterText = shelter ? 'optaget' : 'ledig'
+  const tentText = `${tentsFree} af ${TOTAL_TENTS} ledige`
+  return `Shelter: ${shelterText} · Teltpladser: ${tentText}`
+}
+
+/**
+ * Byg en månedsgrid (mandag-først). Returnerer celler hvor null = tom plads
+ * før månedens første dag, og strenge = YYYY-MM-DD.
+ */
+export function buildMonthGrid(year: number, month: number): (string | null)[] {
+  const first = new Date(year, month, 1)
+  // getDay(): 0=søn..6=lør. Konvertér til mandag-først (0=man..6=søn).
+  const leading = (first.getDay() + 6) % 7
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+  const cells: (string | null)[] = []
+  for (let i = 0; i < leading; i++) cells.push(null)
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push(toISODate(new Date(year, month, d)))
+  }
+  return cells
+}
+
+/** Månedsoverskrift, fx "juni 2026". */
+export function formatMonthTitle(year: number, month: number): string {
+  return new Date(year, month, 1).toLocaleDateString('da-DK', { month: 'long', year: 'numeric' })
+}
+
+/** Lang datolabel, fx "tirsdag 16. juni". */
+export function formatLongDate(iso: string): string {
+  return parseISODate(iso).toLocaleDateString('da-DK', { weekday: 'long', day: 'numeric', month: 'long' })
+}
+
+export const WEEKDAY_LABELS = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn']


### PR DESCRIPTION
## Hvad
Ny **tilgængelighedskalender**: gæster kan se hvilke dage shelter og de tre teltpladser er ledige/optaget, og Elin kan "male" dagene fra admin. Manuel model — ingen automatisk kobling til bookinger.

## Offentligt
- Ny sektion **"Ledige dage"** mellem Priser og Kontakt + menupunkt i toppen
- Måneds-grid, én måned ad gangen, åbner på indeværende måned
- Farvekodede dage (🟢 ledigt · 🟡 delvist · 🔴 fuldt/lukket · ⚪ uden for sæson) med legend
- Fortid nedtonet; detalje ved tryk: *"Shelter: optaget · Teltpladser: 2 af 3 ledige"*

## Admin
- Nyt menupunkt **"Kalender"** (gamle **"Forespørgsler"-link fjernet** — rute/komponent/backend urørt)
- Klik en dag → marker shelter (ledig/optaget) + teltpladser (0–3)
- Genveje **"Luk hele dagen"** og **"Nulstil til ledig"**
- Redigerbare sæsondatoer

## Backend
- Nye tabeller `availability` (sparsom — kun optagede dage) + `season_config` (singleton)
- Offentlig `GET /api/availability`, auth-beskyttede writes (`PUT /:date`, `DELETE /:date`, `PUT /season`)
- Datoer som rene `YYYY-MM-DD`-strenge (`to_char`) for at undgå tidszone-skæve datoer
- `/api/test/reset` rydder de nye tabeller

## Test & verifikation
- Playwright E2E: offentlig visning (mocket API) + fuldt admin-flow — **9/9 grønne**
- Verificeret manuelt i browser: alle dagstilstande, maling, luk/nulstil, sæsonændring, måneds-navigation over årsskifte
- `npm run build` + client-tsc rene

## Noter
- Default-sæson er hardcoded til **2026** (schema/migration/test-reset); Elin kan ændre den i admin
- Migrationen er idempotent (`IF NOT EXISTS`) og kører automatisk via Vercel build

🤖 Generated with [Claude Code](https://claude.com/claude-code)