### PR TITLE
fix: registrér availability-ruten i serverless-handler (prod 404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Dette projekt deployer automatisk via Vercel ved push/merge til `main`.
 | Preview | Vercel Postgres (dev/scratch) | Push til hvilken som helst branch |
 | Development | Vercel Postgres (dev/scratch) | Lokalt |
 
+### VIGTIGT: `api/index.js` er et committet build-artefakt
+- `api/index.js` er den bundlede serverless-funktion, som Vercel deployer **som-det-er** (den genbygges ikke ved deploy).
+- **Enhver ændring i `server/`** (ruter, controllers, schema i `schema.postgres.sql` osv.) kræver, at bundlen genbygges og committes i samme PR:
+  ```
+  npm run build:api   # skriver api/index.js
+  git add api/index.js
+  ```
+- Glemmer du det, deployes frontenden uden den matchende backend → fx 404 på nye API-ruter i produktion.
+- SQL-skemaet bundles ind via `--loader:.sql=text`, og `handler.ts` kører `runMigrations()` idempotent ved cold start — så nye tabeller oprettes automatisk, *forudsat* bundlen er genbygget.
+
 ## Test-regler
 
 - Når du implementerer en feature, skriv altid en Playwright E2E-test der dækker de kritiske brugerflows. Testfiler placeres i `e2e/`-mappen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,15 @@ Dette projekt deployer automatisk via Vercel ved push/merge til `main`.
 | Preview | Vercel Postgres (dev/scratch) | Push til hvilken som helst branch |
 | Development | Vercel Postgres (dev/scratch) | Lokalt |
 
-### VIGTIGT: `api/index.js` er et committet build-artefakt
-- `api/index.js` er den bundlede serverless-funktion, som Vercel deployer **som-det-er** (den genbygges ikke ved deploy).
-- **Enhver ændring i `server/`** (ruter, controllers, schema i `schema.postgres.sql` osv.) kræver, at bundlen genbygges og committes i samme PR:
+### VIGTIGT: nye API-ruter skal registreres i `server/handler.ts`
+- Produktionens serverless-entry er **`server/handler.ts`**, som har sin **egen** liste af `app.use('/api/...')`-mounts. Den deler **ikke** `server/routes/index.ts` (som kun bruges af dev-serveren via `app.ts`).
+- Tilføjer du en ny rute, skal den registreres **begge** steder — ellers virker den lokalt/i E2E men giver **404 i produktion**.
+- `api/index.js` er den bundlede serverless-funktion (committet build-artefakt). Efter enhver `server/`-ændring:
   ```
-  npm run build:api   # skriver api/index.js
+  npm run build:api   # bundler handler.ts → api/index.js
   git add api/index.js
   ```
-- Glemmer du det, deployes frontenden uden den matchende backend → fx 404 på nye API-ruter i produktion.
-- SQL-skemaet bundles ind via `--loader:.sql=text`, og `handler.ts` kører `runMigrations()` idempotent ved cold start — så nye tabeller oprettes automatisk, *forudsat* bundlen er genbygget.
+- SQL-skemaet bundles ind via `--loader:.sql=text`, og `handler.ts` kører `runMigrations()` idempotent ved cold start — så nye tabeller oprettes automatisk i prod-databasen, *forudsat* bundlen er genbygget.
 
 ## Test-regler
 

--- a/api/index.js
+++ b/api/index.js
@@ -33,7 +33,7 @@ __export(handler_exports, {
   default: () => handler
 });
 module.exports = __toCommonJS(handler_exports);
-var import_express6 = __toESM(require("express"));
+var import_express7 = __toESM(require("express"));
 var import_cors = __toESM(require("cors"));
 var import_helmet = __toESM(require("helmet"));
 var import_express_rate_limit = __toESM(require("express-rate-limit"));
@@ -2085,6 +2085,163 @@ router5.patch("/admin/:id/toggle", authenticateToken, facilityController.toggleF
 router5.delete("/admin/:id", authenticateToken, facilityController.deleteFacility.bind(facilityController));
 var facilityRoutes_default = router5;
 
+// server/routes/availabilityRoutes.ts
+var import_express6 = require("express");
+
+// server/repositories/availabilityRepository.ts
+var DEFAULT_SEASON = {
+  season_start: "2026-06-01",
+  season_end: "2026-09-01"
+};
+var AvailabilityRepository = class {
+  /**
+   * Get the (single) season configuration. Dates returned as YYYY-MM-DD
+   * strings via to_char to avoid timezone-skewed Date parsing.
+   */
+  async getSeason() {
+    const row = await queryOne(
+      `SELECT to_char(season_start, 'YYYY-MM-DD') AS season_start,
+              to_char(season_end, 'YYYY-MM-DD') AS season_end
+       FROM season_config WHERE id = 1`
+    );
+    return row ?? DEFAULT_SEASON;
+  }
+  async updateSeason(seasonStart, seasonEnd) {
+    await execute(
+      `INSERT INTO season_config (id, season_start, season_end, updated_at)
+       VALUES (1, $1, $2, CURRENT_TIMESTAMP)
+       ON CONFLICT (id) DO UPDATE
+         SET season_start = EXCLUDED.season_start,
+             season_end = EXCLUDED.season_end,
+             updated_at = CURRENT_TIMESTAMP`,
+      [seasonStart, seasonEnd]
+    );
+    return this.getSeason();
+  }
+  /**
+   * Only returns days that differ from the default (something occupied).
+   */
+  async getOccupiedDays() {
+    return query(
+      `SELECT to_char(date, 'YYYY-MM-DD') AS date, shelter_occupied, tents_occupied
+       FROM availability
+       WHERE shelter_occupied = true OR tents_occupied > 0
+       ORDER BY date ASC`
+    );
+  }
+  /**
+   * Upsert a day. If the day ends up fully free, the row is deleted to keep
+   * the table sparse.
+   */
+  async upsertDay(date, shelterOccupied, tentsOccupied) {
+    if (!shelterOccupied && tentsOccupied === 0) {
+      await this.deleteDay(date);
+      return { date, shelter_occupied: false, tents_occupied: 0 };
+    }
+    await execute(
+      `INSERT INTO availability (date, shelter_occupied, tents_occupied, updated_at)
+       VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+       ON CONFLICT (date) DO UPDATE
+         SET shelter_occupied = EXCLUDED.shelter_occupied,
+             tents_occupied = EXCLUDED.tents_occupied,
+             updated_at = CURRENT_TIMESTAMP`,
+      [date, shelterOccupied, tentsOccupied]
+    );
+    return { date, shelter_occupied: shelterOccupied, tents_occupied: tentsOccupied };
+  }
+  async deleteDay(date) {
+    const result = await execute("DELETE FROM availability WHERE date = $1", [date]);
+    return result.rowCount > 0;
+  }
+};
+var availabilityRepository = new AvailabilityRepository();
+
+// server/controllers/availabilityController.ts
+var DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+var AvailabilityController = class {
+  /**
+   * GET /api/availability (public)
+   * Returns season config + all occupied days. The client computes per-day status.
+   */
+  async getAvailability(_req, res) {
+    try {
+      const [season, days] = await Promise.all([
+        availabilityRepository.getSeason(),
+        availabilityRepository.getOccupiedDays()
+      ]);
+      res.status(200).json({ success: true, data: { season, days } });
+    } catch (error) {
+      logger.error("Error fetching availability", { error: error.message });
+      res.status(500).json({ success: false, message: "Kunne ikke hente tilg\xE6ngelighed" });
+    }
+  }
+  /**
+   * PUT /api/availability/season (admin)
+   */
+  async updateSeason(req, res) {
+    try {
+      const parsed = updateSeasonSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, message: parsed.error.errors[0]?.message ?? "Ugyldige s\xE6sondatoer" });
+        return;
+      }
+      const season = await availabilityRepository.updateSeason(parsed.data.season_start, parsed.data.season_end);
+      res.status(200).json({ success: true, data: season });
+    } catch (error) {
+      logger.error("Error updating season", { error: error.message });
+      res.status(500).json({ success: false, message: "Kunne ikke opdatere s\xE6son" });
+    }
+  }
+  /**
+   * PUT /api/availability/:date (admin)
+   */
+  async upsertDay(req, res) {
+    try {
+      const { date } = req.params;
+      if (!DATE_RE.test(date)) {
+        res.status(400).json({ success: false, message: "Ugyldig dato" });
+        return;
+      }
+      const parsed = upsertAvailabilitySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, message: parsed.error.errors[0]?.message ?? "Ugyldige data" });
+        return;
+      }
+      const day = await availabilityRepository.upsertDay(date, parsed.data.shelter_occupied, parsed.data.tents_occupied);
+      res.status(200).json({ success: true, data: day });
+    } catch (error) {
+      logger.error("Error updating availability", { error: error.message });
+      res.status(500).json({ success: false, message: "Kunne ikke opdatere dagen" });
+    }
+  }
+  /**
+   * DELETE /api/availability/:date (admin) — nulstil til alt ledigt.
+   */
+  async resetDay(req, res) {
+    try {
+      const { date } = req.params;
+      if (!DATE_RE.test(date)) {
+        res.status(400).json({ success: false, message: "Ugyldig dato" });
+        return;
+      }
+      await availabilityRepository.deleteDay(date);
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error("Error resetting availability", { error: error.message });
+      res.status(500).json({ success: false, message: "Kunne ikke nulstille dagen" });
+    }
+  }
+};
+var availabilityController = new AvailabilityController();
+
+// server/routes/availabilityRoutes.ts
+var router6 = (0, import_express6.Router)();
+router6.get("/", availabilityController.getAvailability.bind(availabilityController));
+router6.put("/season", authenticateToken, availabilityController.updateSeason.bind(availabilityController));
+router6.put("/:date", authenticateToken, availabilityController.upsertDay.bind(availabilityController));
+router6.delete("/:date", authenticateToken, availabilityController.resetDay.bind(availabilityController));
+var availabilityRoutes_default = router6;
+
 // server/db/migrate.ts
 var import_config = require("dotenv/config");
 var import_postgres2 = require("@vercel/postgres");
@@ -2260,7 +2417,7 @@ if (isMain) {
 }
 
 // server/handler.ts
-var app = (0, import_express6.default)();
+var app = (0, import_express7.default)();
 app.set("trust proxy", 1);
 app.use((0, import_helmet.default)({
   contentSecurityPolicy: false
@@ -2269,8 +2426,8 @@ app.use((0, import_cors.default)({
   origin: process.env.CORS_ORIGIN || "*",
   credentials: true
 }));
-app.use(import_express6.default.json());
-app.use(import_express6.default.urlencoded({ extended: true }));
+app.use(import_express7.default.json());
+app.use(import_express7.default.urlencoded({ extended: true }));
 var limiter = (0, import_express_rate_limit.default)({
   windowMs: 15 * 60 * 1e3,
   max: 100
@@ -2288,6 +2445,7 @@ app.use("/api/contacts", contactRoutes_default);
 app.use("/api/gallery", galleryRoutes_default);
 app.use("/api/auth", authRoutes_default);
 app.use("/api/facilities", facilityRoutes_default);
+app.use("/api/availability", availabilityRoutes_default);
 app.use((err, _req, res, _next) => {
   console.error("Error:", err);
   res.status(err.status || 500).json({

--- a/api/index.js
+++ b/api/index.js
@@ -597,6 +597,18 @@ var createAdminUserSchema = import_zod2.z.object({
   password: import_zod2.z.string().min(6, "Password skal v\xE6re mindst 6 tegn"),
   is_active: import_zod2.z.boolean().default(true)
 });
+var isoDate = import_zod2.z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Ugyldigt datoformat (forventede YYYY-MM-DD)");
+var upsertAvailabilitySchema = import_zod2.z.object({
+  shelter_occupied: import_zod2.z.boolean(),
+  tents_occupied: import_zod2.z.number().int().min(0, "Mindst 0 teltpladser").max(3, "Max 3 teltpladser")
+});
+var updateSeasonSchema = import_zod2.z.object({
+  season_start: isoDate,
+  season_end: isoDate
+}).refine((data) => data.season_end >= data.season_start, {
+  message: "Slutdato skal v\xE6re samme dag eller efter startdato",
+  path: ["season_end"]
+});
 
 // server/routes/inquiryRoutes.ts
 var router = (0, import_express.Router)();
@@ -2078,7 +2090,152 @@ var import_config = require("dotenv/config");
 var import_postgres2 = require("@vercel/postgres");
 
 // server/db/schema.postgres.sql
-var schema_postgres_default = "-- Vercel Postgres Schema\r\n-- Gallery Images Table\r\nCREATE TABLE IF NOT EXISTS gallery_images (\r\n    id SERIAL PRIMARY KEY,\r\n    title TEXT,\r\n    description TEXT,\r\n    image_url TEXT NOT NULL,\r\n    image_path TEXT,\r\n    sort_order INTEGER DEFAULT 0,\r\n    is_active BOOLEAN DEFAULT true,\r\n    show_in_hero BOOLEAN DEFAULT false,\r\n    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r\n    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r\n);\r\n\r\n-- Create indexes\r\nCREATE INDEX IF NOT EXISTS idx_gallery_images_sort_order ON gallery_images(sort_order);\r\nCREATE INDEX IF NOT EXISTS idx_gallery_images_is_active ON gallery_images(is_active);\r\nCREATE INDEX IF NOT EXISTS idx_gallery_images_created_at ON gallery_images(created_at);\r\n\r\n-- Admin Users Table\r\nCREATE TABLE IF NOT EXISTS admin_users (\r\n    id SERIAL PRIMARY KEY,\r\n    username TEXT UNIQUE NOT NULL,\r\n    email TEXT,\r\n    password_hash TEXT NOT NULL,\r\n    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r\n);\r\n\r\n-- Create unique index for username\r\nCREATE UNIQUE INDEX IF NOT EXISTS idx_admin_users_username ON admin_users(username);\r\n\r\n-- Insert default admin user (password: Susi2010)\r\n-- Password hash: $2b$10$fOzugvgbY6Cglded6fjd2uZC.dj.R.TbgQ.ErwH.CQNgIRj.SytOG\r\nINSERT INTO admin_users (username, password_hash)\r\nVALUES ('admin', '$2b$10$fOzugvgbY6Cglded6fjd2uZC.dj.R.TbgQ.ErwH.CQNgIRj.SytOG')\r\nON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash;\r\n\r\n-- Inquiries Table\r\nCREATE TABLE IF NOT EXISTS inquiries (\r\n    id SERIAL PRIMARY KEY,\r\n    name TEXT NOT NULL,\r\n    email TEXT NOT NULL,\r\n    phone TEXT,\r\n    arrival_date DATE NOT NULL,\r\n    departure_date DATE NOT NULL,\r\n    num_people INTEGER NOT NULL,\r\n    message TEXT,\r\n    status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'confirmed', 'declined', 'completed')),\r\n    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r\n    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r\n);\r\n\r\n-- Create indexes for inquiries\r\nCREATE INDEX IF NOT EXISTS idx_inquiries_status ON inquiries(status);\r\nCREATE INDEX IF NOT EXISTS idx_inquiries_dates ON inquiries(arrival_date, departure_date);\r\nCREATE INDEX IF NOT EXISTS idx_inquiries_created_at ON inquiries(created_at);\r\n\r\n-- Contacts Table\r\nCREATE TABLE IF NOT EXISTS contacts (\r\n    id SERIAL PRIMARY KEY,\r\n    name TEXT NOT NULL,\r\n    email TEXT NOT NULL,\r\n    subject TEXT,\r\n    message TEXT NOT NULL,\r\n    is_read BOOLEAN DEFAULT false,\r\n    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r\n);\r\n\r\n-- Create indexes for contacts\r\nCREATE INDEX IF NOT EXISTS idx_contacts_is_read ON contacts(is_read);\r\nCREATE INDEX IF NOT EXISTS idx_contacts_created_at ON contacts(created_at);\r\n\r\n-- Facilities Table\r\nCREATE TABLE IF NOT EXISTS facilities (\r\n    id SERIAL PRIMARY KEY,\r\n    title TEXT NOT NULL,\r\n    description TEXT,\r\n    icon_name TEXT NOT NULL,\r\n    is_active BOOLEAN DEFAULT true,\r\n    sort_order INTEGER DEFAULT 0,\r\n    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r\n    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r\n);\r\n\r\n-- Create indexes for facilities\r\nCREATE INDEX IF NOT EXISTS idx_facilities_sort_order ON facilities(sort_order);\r\nCREATE INDEX IF NOT EXISTS idx_facilities_is_active ON facilities(is_active);\r\n\r\n-- Remove duplicate facilities before adding unique index\r\nDELETE FROM facilities WHERE id NOT IN (SELECT MIN(id) FROM facilities GROUP BY title);\r\n\r\n-- Add unique index on title to prevent duplicates from repeated migrations\r\nCREATE UNIQUE INDEX IF NOT EXISTS idx_facilities_title_unique ON facilities(title);\r\n\r\n-- Seed initial facilities ONLY if the table is empty.\r\n-- This preserves user deletions: n\xE5r brugeren har slettet en facilitet i admin,\r\n-- m\xE5 migrationen ikke genoprette den ved n\xE6ste deploy.\r\nINSERT INTO facilities (title, description, icon_name, is_active, sort_order)\r\nSELECT v.title, v.description, v.icon_name, v.is_active, v.sort_order\r\nFROM (VALUES\r\n    ('Toilet & Bad', 'Adgang til toilet og brusebad i forbindelse med overnatningen', 'Home', true, 1),\r\n    ('Str\xF8m', 'Mulighed for at oplade telefon og cykellygter', 'Zap', true, 2),\r\n    ('K\xF8kkenadgang', 'Mulighed for at tilberede let mad og drikke', 'UtensilsCrossed', true, 3),\r\n    ('WiFi', 'Gratis tr\xE5dl\xF8st internet i hele haven', 'Wifi', true, 4),\r\n    ('Sikkert Omr\xE5de', 'Privat og sikkert omr\xE5de til parkering af cykler', 'ShieldCheck', true, 5),\r\n    ('Udend\xF8rs Lys', 'God belysning i haven om aftenen', 'Moon', true, 6),\r\n    ('F\xE6lles Opholdsrum', 'Hyggeligt omr\xE5de at m\xF8de andre cyklister', 'Users', true, 7),\r\n    ('Kort & Vejledning', 'Hj\xE6lp til at planl\xE6gge din videre rute', 'Map', true, 8)\r\n) AS v(title, description, icon_name, is_active, sort_order)\r\nWHERE NOT EXISTS (SELECT 1 FROM facilities)\r\nON CONFLICT (title) DO NOTHING;\r\n\r\n-- Remove duplicate gallery images before adding unique index\r\nDELETE FROM gallery_images WHERE id NOT IN (SELECT MIN(id) FROM gallery_images GROUP BY image_url);\r\n\r\n-- Add show_in_hero column if it doesn't exist (migration for existing databases)\r\nALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS show_in_hero BOOLEAN DEFAULT false;\r\n\r\n-- Add unique index on image_url to prevent duplicates from repeated migrations\r\nCREATE UNIQUE INDEX IF NOT EXISTS idx_gallery_images_url_unique ON gallery_images(image_url);\r\n\r\n-- No sample gallery images \u2014 all images are managed via the admin panel\r\n";
+var schema_postgres_default = `-- Vercel Postgres Schema\r
+-- Gallery Images Table\r
+CREATE TABLE IF NOT EXISTS gallery_images (\r
+    id SERIAL PRIMARY KEY,\r
+    title TEXT,\r
+    description TEXT,\r
+    image_url TEXT NOT NULL,\r
+    image_path TEXT,\r
+    sort_order INTEGER DEFAULT 0,\r
+    is_active BOOLEAN DEFAULT true,\r
+    show_in_hero BOOLEAN DEFAULT false,\r
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Create indexes\r
+CREATE INDEX IF NOT EXISTS idx_gallery_images_sort_order ON gallery_images(sort_order);\r
+CREATE INDEX IF NOT EXISTS idx_gallery_images_is_active ON gallery_images(is_active);\r
+CREATE INDEX IF NOT EXISTS idx_gallery_images_created_at ON gallery_images(created_at);\r
+\r
+-- Admin Users Table\r
+CREATE TABLE IF NOT EXISTS admin_users (\r
+    id SERIAL PRIMARY KEY,\r
+    username TEXT UNIQUE NOT NULL,\r
+    email TEXT,\r
+    password_hash TEXT NOT NULL,\r
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Create unique index for username\r
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admin_users_username ON admin_users(username);\r
+\r
+-- Insert default admin user (password: Susi2010)\r
+-- Password hash: $2b$10$fOzugvgbY6Cglded6fjd2uZC.dj.R.TbgQ.ErwH.CQNgIRj.SytOG\r
+INSERT INTO admin_users (username, password_hash)\r
+VALUES ('admin', '$2b$10$fOzugvgbY6Cglded6fjd2uZC.dj.R.TbgQ.ErwH.CQNgIRj.SytOG')\r
+ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash;\r
+\r
+-- Inquiries Table\r
+CREATE TABLE IF NOT EXISTS inquiries (\r
+    id SERIAL PRIMARY KEY,\r
+    name TEXT NOT NULL,\r
+    email TEXT NOT NULL,\r
+    phone TEXT,\r
+    arrival_date DATE NOT NULL,\r
+    departure_date DATE NOT NULL,\r
+    num_people INTEGER NOT NULL,\r
+    message TEXT,\r
+    status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'confirmed', 'declined', 'completed')),\r
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Create indexes for inquiries\r
+CREATE INDEX IF NOT EXISTS idx_inquiries_status ON inquiries(status);\r
+CREATE INDEX IF NOT EXISTS idx_inquiries_dates ON inquiries(arrival_date, departure_date);\r
+CREATE INDEX IF NOT EXISTS idx_inquiries_created_at ON inquiries(created_at);\r
+\r
+-- Contacts Table\r
+CREATE TABLE IF NOT EXISTS contacts (\r
+    id SERIAL PRIMARY KEY,\r
+    name TEXT NOT NULL,\r
+    email TEXT NOT NULL,\r
+    subject TEXT,\r
+    message TEXT NOT NULL,\r
+    is_read BOOLEAN DEFAULT false,\r
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Create indexes for contacts\r
+CREATE INDEX IF NOT EXISTS idx_contacts_is_read ON contacts(is_read);\r
+CREATE INDEX IF NOT EXISTS idx_contacts_created_at ON contacts(created_at);\r
+\r
+-- Facilities Table\r
+CREATE TABLE IF NOT EXISTS facilities (\r
+    id SERIAL PRIMARY KEY,\r
+    title TEXT NOT NULL,\r
+    description TEXT,\r
+    icon_name TEXT NOT NULL,\r
+    is_active BOOLEAN DEFAULT true,\r
+    sort_order INTEGER DEFAULT 0,\r
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\r
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Create indexes for facilities\r
+CREATE INDEX IF NOT EXISTS idx_facilities_sort_order ON facilities(sort_order);\r
+CREATE INDEX IF NOT EXISTS idx_facilities_is_active ON facilities(is_active);\r
+\r
+-- Remove duplicate facilities before adding unique index\r
+DELETE FROM facilities WHERE id NOT IN (SELECT MIN(id) FROM facilities GROUP BY title);\r
+\r
+-- Add unique index on title to prevent duplicates from repeated migrations\r
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facilities_title_unique ON facilities(title);\r
+\r
+-- Seed initial facilities ONLY if the table is empty.\r
+-- This preserves user deletions: n\xE5r brugeren har slettet en facilitet i admin,\r
+-- m\xE5 migrationen ikke genoprette den ved n\xE6ste deploy.\r
+INSERT INTO facilities (title, description, icon_name, is_active, sort_order)\r
+SELECT v.title, v.description, v.icon_name, v.is_active, v.sort_order\r
+FROM (VALUES\r
+    ('Toilet & Bad', 'Adgang til toilet og brusebad i forbindelse med overnatningen', 'Home', true, 1),\r
+    ('Str\xF8m', 'Mulighed for at oplade telefon og cykellygter', 'Zap', true, 2),\r
+    ('K\xF8kkenadgang', 'Mulighed for at tilberede let mad og drikke', 'UtensilsCrossed', true, 3),\r
+    ('WiFi', 'Gratis tr\xE5dl\xF8st internet i hele haven', 'Wifi', true, 4),\r
+    ('Sikkert Omr\xE5de', 'Privat og sikkert omr\xE5de til parkering af cykler', 'ShieldCheck', true, 5),\r
+    ('Udend\xF8rs Lys', 'God belysning i haven om aftenen', 'Moon', true, 6),\r
+    ('F\xE6lles Opholdsrum', 'Hyggeligt omr\xE5de at m\xF8de andre cyklister', 'Users', true, 7),\r
+    ('Kort & Vejledning', 'Hj\xE6lp til at planl\xE6gge din videre rute', 'Map', true, 8)\r
+) AS v(title, description, icon_name, is_active, sort_order)\r
+WHERE NOT EXISTS (SELECT 1 FROM facilities)\r
+ON CONFLICT (title) DO NOTHING;\r
+\r
+-- Remove duplicate gallery images before adding unique index\r
+DELETE FROM gallery_images WHERE id NOT IN (SELECT MIN(id) FROM gallery_images GROUP BY image_url);\r
+\r
+-- Add show_in_hero column if it doesn't exist (migration for existing databases)\r
+ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS show_in_hero BOOLEAN DEFAULT false;\r
+\r
+-- Add unique index on image_url to prevent duplicates from repeated migrations\r
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gallery_images_url_unique ON gallery_images(image_url);\r
+\r
+-- No sample gallery images \u2014 all images are managed via the admin panel\r
+\r
+-- Availability Table\r
+-- Sparse: kun dage der afviger fra "alt ledigt" gemmes. Ingen r\xE6kke = alt ledigt.\r
+CREATE TABLE IF NOT EXISTS availability (\r
+    date DATE PRIMARY KEY,\r
+    shelter_occupied BOOLEAN NOT NULL DEFAULT false,\r
+    tents_occupied INTEGER NOT NULL DEFAULT 0 CHECK (tents_occupied >= 0 AND tents_occupied <= 3),\r
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Season Config Table (singleton-r\xE6kke med id = 1)\r
+CREATE TABLE IF NOT EXISTS season_config (\r
+    id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),\r
+    season_start DATE NOT NULL,\r
+    season_end DATE NOT NULL,\r
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\r
+);\r
+\r
+-- Seed default season (1. juni \u2013 1. september 2026), kun hvis tabellen er tom.\r
+INSERT INTO season_config (id, season_start, season_end)\r
+VALUES (1, '2026-06-01', '2026-09-01')\r
+ON CONFLICT (id) DO NOTHING;\r
+`;
 
 // server/db/migrate.ts
 async function runMigrations() {

--- a/server/handler.ts
+++ b/server/handler.ts
@@ -8,6 +8,7 @@ import contactRoutes from './routes/contactRoutes';
 import galleryRoutes from './routes/galleryRoutes';
 import authRoutes from './routes/authRoutes';
 import facilityRoutes from './routes/facilityRoutes';
+import availabilityRoutes from './routes/availabilityRoutes';
 import { runMigrations } from './db/migrate';
 
 const app = express();
@@ -50,6 +51,7 @@ app.use('/api/contacts', contactRoutes);
 app.use('/api/gallery', galleryRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/facilities', facilityRoutes);
+app.use('/api/availability', availabilityRoutes);
 
 // Error handler
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {


### PR DESCRIPTION
## Den egentlige årsag på 404''en
`/api/availability` gav fortsat 404 i produktion efter #41. Roden er, at produktionens serverless-entry **`server/handler.ts`** har sin **egen** liste af `app.use(''/api/...'')`-mounts og **ikke** deler `server/routes/index.ts` (som kun bruges af dev-serveren via `app.ts`).

Tilgængelighedskalenderen tilføjede kun ruten i `routes/index.ts`, så den virkede **lokalt + i E2E**, men `handler.ts` registrerede den aldrig → **404 i prod**. (#41 genbyggede bundlen, men bundlen var "korrekt" for det `handler.ts` indeholdt — uden ruten.)

## Fix
- `app.use(''/api/availability'', availabilityRoutes)` tilføjet i `server/handler.ts`
- `api/index.js` genbygget — verificeret at controlleren nu er i bundlen (mount + `getOccupiedDays` + controller-besked til stede; 71.8 → 77.7 kb)
- `CLAUDE.md`-noten opdateret til at pege på den faktiske fælde (nye ruter skal registreres **begge** steder)

## Efter merge
Cold-start kører migrationen (opretter `availability` + `season_config` i prod-db), og `/api/availability` svarer korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)