### PR TITLE
Kobl kontaktsektionens sæson til admin-styret sæson

### DIFF
--- a/e2e/availability.spec.ts
+++ b/e2e/availability.spec.ts
@@ -53,6 +53,29 @@ test.describe('Tilgængelighedskalender', () => {
     await expect(page.locator('#availability').getByText('Shelter: optaget')).toBeVisible();
   });
 
+  test('kontaktsektionens åbningstider følger den sæson API\'et leverer', async ({ page }) => {
+    // Mock en sæson der adskiller sig fra den hårdkodede fallback (2026, 1. juni – 1. september).
+    await page.route('**/api/availability', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            season: { season_start: '2027-05-01', season_end: '2027-09-30' },
+            days: [],
+          },
+        }),
+      });
+    });
+
+    await page.goto('/');
+
+    const contact = page.locator('#contact');
+    await expect(contact.getByText('Sæson 2027')).toBeVisible();
+    await expect(contact.getByText('1. maj – 30. september')).toBeVisible();
+  });
+
   test('admin kan markere, lukke og nulstille en dag samt ændre sæson', async ({ page, request }) => {
     const iso = seedDateISO();
 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,8 +1,29 @@
+import { useState, useEffect } from 'react'
 import LocationMap from './LocationMap'
 import PhoneIcon from './icons/PhoneIcon'
 import EmailIcon from './icons/EmailIcon'
+import { API_URL } from '../config/api'
+import { formatSeasonRange, seasonYear, type SeasonConfig } from '../utils/availability'
+
+const DEFAULT_SEASON: SeasonConfig = { season_start: '2026-06-01', season_end: '2026-09-01' }
 
 const Contact = () => {
+  const [season, setSeason] = useState<SeasonConfig>(DEFAULT_SEASON)
+
+  useEffect(() => {
+    const fetchSeason = async () => {
+      try {
+        const response = await fetch(`${API_URL}/availability`)
+        if (!response.ok) throw new Error('Failed to fetch availability')
+        const data = await response.json()
+        setSeason(data.data?.season ?? DEFAULT_SEASON)
+      } catch (err) {
+        console.error('Error fetching season:', err)
+        // Behold fallback-sæsonen, så åbningstiderne aldrig står tomme.
+      }
+    }
+    fetchSeason()
+  }, [])
 
   return (
     <section id="contact" className="bg-white dark:bg-gray-900 transition-colors">
@@ -58,8 +79,8 @@ const Contact = () => {
                   </div>
                   <div className="ml-4">
                     <h4 className="font-semibold text-gray-900 dark:text-white">Åbningstider</h4>
-                    <p className="text-gray-600 dark:text-gray-300 mt-1">Sæson 2026</p>
-                    <p className="text-gray-600 dark:text-gray-300">1. juni – 1. september</p>
+                    <p className="text-gray-600 dark:text-gray-300 mt-1">Sæson {seasonYear(season)}</p>
+                    <p className="text-gray-600 dark:text-gray-300">{formatSeasonRange(season)}</p>
                   </div>
                 </div>
 

--- a/src/utils/availability.ts
+++ b/src/utils/availability.ts
@@ -107,4 +107,19 @@ export function formatLongDate(iso: string): string {
   return parseISODate(iso).toLocaleDateString('da-DK', { weekday: 'long', day: 'numeric', month: 'long' })
 }
 
+/** Dato uden ugedag, fx "1. juni". */
+export function formatDayMonth(iso: string): string {
+  return parseISODate(iso).toLocaleDateString('da-DK', { day: 'numeric', month: 'long' })
+}
+
+/** Sæsonens datointerval som tekst, fx "1. juni – 1. september". */
+export function formatSeasonRange(season: SeasonConfig): string {
+  return `${formatDayMonth(season.season_start)} – ${formatDayMonth(season.season_end)}`
+}
+
+/** Årstallet for sæsonen, udledt af startdatoen, fx 2026. */
+export function seasonYear(season: SeasonConfig): number {
+  return parseISODate(season.season_start).getFullYear()
+}
+
 export const WEEKDAY_LABELS = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn']


### PR DESCRIPTION
## Hvad
"Åbningstider" i Kontakt-sektionen var hårdkodet (`Sæson 2026` / `1. juni – 1. september`) og fulgte ikke med, når sæsonen blev ændret i admin-panelet.

Nu henter Contact sæsonen fra `GET /api/availability` — præcis som kalenderen allerede gør — og formaterer den dynamisk. Ændrer Elin sæsonen i admin, opdateres teksten i Kontakt automatisk.

## Ændringer
- `src/utils/availability.ts`: nye helpers `formatDayMonth()`, `formatSeasonRange()` og `seasonYear()`.
- `src/components/Contact.tsx`: henter sæsonen fra API; viser `Sæson <år>` og `<start> – <slut>`. Beholder den hårdkodede standardsæson som fallback, hvis API-kaldet fejler, så sektionen aldrig står tom.
- `e2e/availability.spec.ts`: ny test der mocker en afvigende sæson (2027, 1. maj – 30. september) og bekræfter at Kontakt afspejler den.

## Test
- `npx playwright test availability.spec.ts` → 3/3 passerer.
- `tsc --noEmit` → ren.

## Note
Footerens "Åbningstider" er check-in/check-out-tider (ikke sæson) og er bevidst urørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)