### PR TITLE
Komprimér galleri-billeder for at få Vercel Blob-egress ned

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1017,6 +1017,27 @@ var galleryRepository = new GalleryRepository();
 var import_multer = __toESM(require("multer"));
 var import_path2 = __toESM(require("path"));
 var import_fs2 = __toESM(require("fs"));
+
+// server/utils/imageCompression.ts
+var import_sharp = __toESM(require("sharp"));
+var MAX_WIDTH = 1600;
+var WEBP_QUALITY = 80;
+async function compressImage(input) {
+  const image = (0, import_sharp.default)(input, { failOn: "none" });
+  const metadata = await image.metadata();
+  let pipeline = image.rotate();
+  if (metadata.width && metadata.width > MAX_WIDTH) {
+    pipeline = pipeline.resize({ width: MAX_WIDTH, withoutEnlargement: true });
+  }
+  const buffer = await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer();
+  return {
+    buffer,
+    contentType: "image/webp",
+    ext: ".webp"
+  };
+}
+
+// server/middleware/upload.ts
 var fileFilter = (_req, file, cb) => {
   const allowedTypes = config.upload.allowedTypes;
   const fileMime = file.mimetype.toLowerCase();
@@ -1034,19 +1055,24 @@ var upload = (0, import_multer.default)({
     files: 1
   }
 });
-async function uploadToBlob(buffer, originalname, mimetype) {
+async function uploadToBlob(buffer, originalname) {
+  const { buffer: optimized, contentType, ext } = await compressImage(buffer);
   const timestamp = Date.now();
   const randomString = Math.random().toString(36).substring(2, 8);
-  const ext = import_path2.default.extname(originalname).toLowerCase();
   const filename = `${timestamp}-${randomString}${ext}`;
   if (config.blob.readWriteToken) {
     const { put } = await import("@vercel/blob");
-    const blob = await put(`gallery/${filename}`, buffer, {
+    const blob = await put(`gallery/${filename}`, optimized, {
       access: "public",
-      contentType: mimetype,
+      contentType,
       token: config.blob.readWriteToken
     });
-    logger.info("File uploaded to Vercel Blob", { url: blob.url });
+    logger.info("File uploaded to Vercel Blob", {
+      url: blob.url,
+      originalName: originalname,
+      originalBytes: buffer.length,
+      optimizedBytes: optimized.length
+    });
     return blob.url;
   } else {
     const tmpDir = "/tmp/uploads";
@@ -1054,8 +1080,8 @@ async function uploadToBlob(buffer, originalname, mimetype) {
       import_fs2.default.mkdirSync(tmpDir, { recursive: true });
     }
     const filePath = import_path2.default.join(tmpDir, filename);
-    import_fs2.default.writeFileSync(filePath, buffer);
-    logger.info("File saved to local /tmp fallback", { filePath });
+    import_fs2.default.writeFileSync(filePath, optimized);
+    logger.info("File saved to local /tmp fallback", { filePath, originalName: originalname });
     return `/tmp-uploads/${filename}`;
   }
 }
@@ -1207,7 +1233,7 @@ var GalleryController = class {
     try {
       const validatedData = createGalleryImageSchema.parse(req.body);
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname, req.file.mimetype);
+        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
         validatedData.image_url = blobUrl;
       }
       const image = await galleryRepository.createImage({
@@ -1248,7 +1274,7 @@ var GalleryController = class {
       }
       const validatedData = updateGalleryImageSchema.parse(req.body);
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname, req.file.mimetype);
+        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
         validatedData.image_url = blobUrl;
       }
       const image = await galleryRepository.updateImage(id, validatedData);

--- a/docs/blob-egress-vurdering.md
+++ b/docs/blob-egress-vurdering.md
@@ -1,0 +1,68 @@
+# Vurdering: langsigtet løsning på Vercel Blob-egress
+
+Kontekst: Galleri- og hero-billeder serveres direkte fra Vercel Blob. Egress
+(data ud) ramte gratis-tierens ~10 GB/måned-loft (juli 2026). Denne PR angriber
+problemet med komprimering (nedskalering + WebP), både for eksisterende filer
+(`npm run blob:compress`) og som delt helper klar til upload-pathen. Dette
+dokument vurderer, om vi bør flytte væk fra Vercel Blob på sigt.
+
+## Hvor stort er problemet efter komprimering?
+
+Komprimering alene skærer typisk hver fil 10-30×. En hero-visning på ~15 MB
+falder til ~0,5-1 MB. Med det nuværende trafikniveau (~650 forsidebesøg ramte
+loftet) betyder det, at vi lander langt under 10 GB/måned. **For den nuværende
+trafik er komprimering sandsynligvis nok** — en migrering er en optimering, ikke
+en nødvendighed, medmindre trafikken vokser markant eller vi vil have et fast
+loft-frit setup.
+
+## Muligheder
+
+### 1. Bliv på Vercel Blob + komprimering (denne PR)
+- **Fordele:** Ingen ny infrastruktur, ingen kodeændring i upload/servering ud
+  over den delte helper, ingen ekstra hemmeligheder. Allerede integreret.
+- **Ulemper:** Egress er stadig meget-bill't men ikke gratis; ved kraftig vækst
+  kan loftet rammes igen. Ingen on-the-fly transformationer (vi bager én
+  størrelse ved upload).
+- **Egnet når:** Trafik forbliver lav-moderat. Dette er standardanbefalingen.
+
+### 2. Cloudflare R2
+- **Model:** S3-kompatibelt object storage med **nul egress-gebyr**; man betaler
+  kun for lagring (~$0,015/GB/md) og operationer. Ingen båndbredde-loft.
+- **Fordele:** Fjerner egress-bekymringen permanent. Billig lagring. Kan sættes
+  bag Cloudflare CDN gratis.
+- **Ulemper:** Migrering kræver: nyt SDK (`@aws-sdk/client-s3` eller Cloudflare
+  SDK), ombygning af `uploadToBlob`, en bucket + API-tokens som nye
+  Vercel-miljøvariabler, og en engangs-kopiering af eksisterende filer + DB
+  URL-opdatering (samme mønster som `compress-blobs.ts`). Ingen indbygget
+  billedtransformation (medmindre man tilføjer Cloudflare Images oveni).
+- **Egnet når:** Vi vil have et permanent egress-frit fundament og er villige
+  til én migreringsindsats.
+
+### 3. Cloudinary
+- **Model:** Dedikeret billed-CDN med on-the-fly transformationer (resize,
+  format, kvalitet via URL-parametre) og auto-WebP/AVIF. Gratis-tier ~25
+  "credits" (≈ 25 GB lagring/båndbredde eller transformationer).
+- **Fordele:** Ville gøre både komprimering OG thumbnail-varianten overflødig —
+  man uploader originalen og henter `.../w_1600,q_auto,f_auto/...` til hero og
+  `.../w_400,.../` til grid. Bedst mulige billedhåndtering med mindst kode
+  fremadrettet.
+- **Ulemper:** Endnu en tredjeparts-konto/leverandør-lock-in. Gratis-tieren har
+  også et loft (kan rammes ved vækst, men transformationer strækker det langt).
+  Migrering svarer til R2 i indsats.
+- **Egnet når:** Vi forventer at ville lave flere billedstørrelser/-varianter og
+  vil have det håndteret automatisk frem for i kode.
+
+## Anbefaling
+
+1. **Nu:** Kør `npm run blob:compress` mod produktion for at skære den
+   eksisterende egress (denne PR). Overvåg forbruget via Vercel Analytics den
+   næste måned.
+2. **Fremadrettet (lille opfølgnings-PR):** Kobl den delte `compressImage`-helper
+   ind i `uploadToBlob`, så nye uploads også komprimeres automatisk — ellers
+   vokser problemet igen ved næste billed-upload. Det er ~2 linjer og bruger
+   koden fra denne PR.
+3. **Kun hvis trafikken vokser ud over komprimeringens råderum:** Migrér til
+   **Cloudflare R2** for permanent nul-egress (simplest mental model, ingen
+   leverandør-transformationslogik), eller **Cloudinary** hvis vi på det
+   tidspunkt også vil have automatiske billedvarianter. Ingen af delene er
+   nødvendige i dag.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,8 @@ export default [
         clearTimeout: 'readonly',
         setInterval: 'readonly',
         clearInterval: 'readonly',
+        fetch: 'readonly',
+        URL: 'readonly',
       },
     },
     plugins: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/server'],
   testMatch: ['**/__tests__/**/*.ts', '**/*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
-    '!src/**/*.test.ts',
-    '!src/**/__tests__/**',
+    'server/**/*.ts',
+    '!**/*.test.ts',
+    '!**/__tests__/**',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^19.0.0",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.10.1",
+        "sharp": "^0.35.3",
         "winston": "^3.11.0",
         "zod": "^3.22.4"
       },
@@ -1400,6 +1401,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
@@ -2002,6 +2013,506 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -10205,9 +10716,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10385,6 +10896,55 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11188,7 +11748,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
     "db:migrate": "esbuild server/db/migrate.ts --bundle --platform=node --format=cjs --packages=external --loader:.sql=text --outfile=node_modules/.cache/migrate.cjs && node node_modules/.cache/migrate.cjs",
-    "blob:cleanup": "tsx server/scripts/cleanup-blobs.ts"
+    "blob:cleanup": "tsx server/scripts/cleanup-blobs.ts",
+    "blob:compress": "tsx server/scripts/compress-blobs.ts",
+    "blob:diagnose": "tsx server/scripts/diagnose-blobs.ts",
+    "prod-env": "node scripts/with-prod-env.mjs"
   },
   "keywords": [
     "camping",
@@ -49,6 +52,7 @@
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.10.1",
+    "sharp": "^0.35.3",
     "winston": "^3.11.0",
     "zod": "^3.22.4"
   },

--- a/scripts/with-prod-env.mjs
+++ b/scripts/with-prod-env.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Kør en kommando med produktions-miljøvariabler i .env — UDEN at miste din
+ * lokale dev-.env.
+ *
+ * `vercel env pull .env --environment=production` OVERSKRIVER .env. Dette script
+ * pakker operationen ind, så din nuværende .env altid lægges tilbage bagefter —
+ * også hvis den indre kommando fejler eller du afbryder med Ctrl+C.
+ *
+ * Flow:
+ *   1. Tag en backup af den nuværende .env (til en midlertidig .env.<ts>.bak).
+ *   2. `vercel env pull .env --environment=production --yes`.
+ *   3. Kør kommandoen du gav med (prod-værdier er nu i .env).
+ *   4. Læg din oprindelige .env tilbage og slet backuppen.
+ *
+ * Brug:
+ *   node scripts/with-prod-env.mjs "npm run blob:compress"
+ *   node scripts/with-prod-env.mjs "npm run blob:compress -- --apply"
+ *   npm run prod-env -- "npm run blob:compress -- --apply"
+ *
+ * Uden argument åbnes ingen kommando — så pulls du bare prod-env sikkert ind,
+ * kører selv dine kommandoer, og scriptet restorer når du trykker Enter.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, copyFileSync, unlinkSync, rmSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const envPath = path.join(root, '.env');
+const backupPath = path.join(root, `.env.${Date.now()}.bak`);
+
+const command = process.argv.slice(2).join(' ').trim();
+const hadOriginalEnv = existsSync(envPath);
+
+function log(msg) {
+  console.log(`\x1b[36m[prod-env]\x1b[0m ${msg}`);
+}
+
+function restore() {
+  if (hadOriginalEnv) {
+    if (existsSync(backupPath)) {
+      copyFileSync(backupPath, envPath);
+      rmSync(backupPath, { force: true });
+      log('♻️  Lokal dev-.env lagt tilbage.');
+    }
+  } else if (existsSync(envPath)) {
+    // Der var ingen .env før — fjern den prod-fil vi hentede.
+    unlinkSync(envPath);
+    log('♻️  Fjernede den hentede prod-.env (der var ingen .env før).');
+  }
+}
+
+// Sørg for at vi altid restorer — også ved Ctrl+C.
+let restored = false;
+function safeRestore() {
+  if (restored) return;
+  restored = true;
+  try {
+    restore();
+  } catch (err) {
+    console.error(`\x1b[31m[prod-env] Kunne IKKE restore .env automatisk!\x1b[0m`);
+    console.error(`   Din backup ligger i: ${backupPath}`);
+    console.error(`   Læg den manuelt tilbage som .env.`);
+    console.error(err);
+  }
+}
+process.on('SIGINT', () => {
+  console.log('');
+  safeRestore();
+  process.exit(130);
+});
+
+function main() {
+  // 1. Backup
+  if (hadOriginalEnv) {
+    copyFileSync(envPath, backupPath);
+    log(`📦 Backup af nuværende .env → ${path.basename(backupPath)}`);
+  } else {
+    log('ℹ️  Ingen eksisterende .env at tage backup af.');
+  }
+
+  // 2. Pull prod-env
+  log('⬇️  Henter produktions-miljøvariabler…');
+  const pull = spawnSync(
+    'vercel',
+    ['env', 'pull', '.env', '--environment=production', '--yes'],
+    { cwd: root, stdio: 'inherit', shell: true }
+  );
+  if (pull.status !== 0) {
+    log('❌ `vercel env pull` fejlede — restorer og afbryder.');
+    safeRestore();
+    process.exit(pull.status ?? 1);
+  }
+
+  // 3. Kør kommandoen (eller vent på Enter hvis ingen kommando er givet)
+  let commandStatus = 0;
+  if (command) {
+    log(`▶️  Kører: ${command}`);
+    const run = spawnSync(command, { cwd: root, stdio: 'inherit', shell: true });
+    commandStatus = run.status ?? 1;
+    log(commandStatus === 0 ? '✅ Kommando færdig.' : `⚠️  Kommando afsluttede med kode ${commandStatus}.`);
+  } else {
+    log('Prod-env er nu i .env. Kør dine kommandoer i en ANDEN terminal.');
+    log('Tryk Enter her når du er færdig for at lægge din dev-.env tilbage…');
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    // Bloker synkront-agtigt: vent på Enter før vi går videre til restore.
+    const wait = () => new Promise((resolve) => rl.question('', () => { rl.close(); resolve(); }));
+    return wait().then(() => {
+      safeRestore();
+      process.exit(0);
+    });
+  }
+
+  // 4. Restore
+  safeRestore();
+  process.exit(commandStatus);
+}
+
+main();

--- a/server/controllers/galleryController.ts
+++ b/server/controllers/galleryController.ts
@@ -136,7 +136,7 @@ export class GalleryController {
 
       // Upload file to blob storage if provided
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname, req.file.mimetype);
+        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
         validatedData.image_url = blobUrl;
       }
 
@@ -185,7 +185,7 @@ export class GalleryController {
 
       // Upload file to blob storage if provided
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname, req.file.mimetype);
+        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
         validatedData.image_url = blobUrl;
       }
 

--- a/server/middleware/upload.ts
+++ b/server/middleware/upload.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { Request, Response, NextFunction } from 'express';
 import { config } from '../config/env';
 import { logger } from '../config/logger';
+import { compressImage } from '../utils/imageCompression';
 
 /**
  * Configure multer with memory storage (file lives in req.file.buffer)
@@ -31,27 +32,35 @@ export const upload = multer({
 
 /**
  * Upload a file buffer to Vercel Blob (production) or /tmp (local dev).
- * Returns the public URL for the uploaded file.
+ *
+ * The buffer is compressed first (downscaled + converted to WebP) to keep
+ * Vercel Blob egress low — the raw upload could be up to 5 MB, the compressed
+ * version is typically 10-30× smaller. Returns the public URL for the file.
  */
 export async function uploadToBlob(
   buffer: Buffer,
-  originalname: string,
-  mimetype: string
+  originalname: string
 ): Promise<string> {
+  const { buffer: optimized, contentType, ext } = await compressImage(buffer);
+
   const timestamp = Date.now();
   const randomString = Math.random().toString(36).substring(2, 8);
-  const ext = path.extname(originalname).toLowerCase();
   const filename = `${timestamp}-${randomString}${ext}`;
 
   if (config.blob.readWriteToken) {
     // Production: upload to Vercel Blob
     const { put } = await import('@vercel/blob');
-    const blob = await put(`gallery/${filename}`, buffer, {
+    const blob = await put(`gallery/${filename}`, optimized, {
       access: 'public',
-      contentType: mimetype,
+      contentType,
       token: config.blob.readWriteToken,
     });
-    logger.info('File uploaded to Vercel Blob', { url: blob.url });
+    logger.info('File uploaded to Vercel Blob', {
+      url: blob.url,
+      originalName: originalname,
+      originalBytes: buffer.length,
+      optimizedBytes: optimized.length,
+    });
     return blob.url;
   } else {
     // Local dev fallback: save to /tmp/uploads/
@@ -60,8 +69,8 @@ export async function uploadToBlob(
       fs.mkdirSync(tmpDir, { recursive: true });
     }
     const filePath = path.join(tmpDir, filename);
-    fs.writeFileSync(filePath, buffer);
-    logger.info('File saved to local /tmp fallback', { filePath });
+    fs.writeFileSync(filePath, optimized);
+    logger.info('File saved to local /tmp fallback', { filePath, originalName: originalname });
     return `/tmp-uploads/${filename}`;
   }
 }

--- a/server/scripts/compress-blobs.ts
+++ b/server/scripts/compress-blobs.ts
@@ -1,0 +1,165 @@
+import { put, del } from '@vercel/blob';
+import { query, execute } from '../db/database.postgres';
+import { config } from '../config/env';
+import { compressImage } from '../utils/imageCompression';
+
+/**
+ * Komprimerer eksisterende galleri-billeder i Vercel Blob.
+ *
+ * De billeder der allerede ligger i blobben blev uploadet i fuld opløsning
+ * (op til 5 MB) uden komprimering, og det er dem der driver egress-forbruget
+ * lige nu. Nye uploads hjælper ikke på det der allerede er der — derfor dette
+ * engangs-script.
+ *
+ * For hvert billede der stadig er refereret i gallery_images:
+ *   1. Hent den nuværende blob-fil.
+ *   2. Komprimér (nedskalér til maks. bredde + WebP) via delt helper.
+ *   3. Hvis besparelsen er betydelig: upload den komprimerede fil som ny blob,
+ *      opdatér image_url i databasen og slet den gamle blob.
+ *
+ * Idempotent: allerede-komprimerede billeder giver ingen betydelig besparelse
+ * og springes over, så scriptet kan køres flere gange uden skade.
+ *
+ * Kør uden flag = dry-run (viser kun hvad der ville ske).
+ * Kør med --apply = udfører faktisk komprimering, DB-opdatering og sletning.
+ *
+ * Kræver at .env peger på det rigtige miljø (blob-token + DB). Til produktion:
+ *   vercel env pull .env --environment=production
+ */
+
+// Minimumsbesparelse før det er værd at genoploade (og betale en download-egress
+// for at hente originalen). Under dette springes billedet over.
+const MIN_SAVING_RATIO = 0.1; // 10 %
+
+/** Genkender en Vercel Blob-URL under gallery/-prefixet. */
+function isGalleryBlobUrl(url: string): boolean {
+  return /blob\.vercel-storage\.com\/gallery\//.test(url);
+}
+
+function newBlobPath(ext: string): string {
+  const timestamp = Date.now();
+  const randomString = Math.random().toString(36).substring(2, 8);
+  return `gallery/${timestamp}-${randomString}${ext}`;
+}
+
+function formatKB(bytes: number): string {
+  return `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+async function main() {
+  const shouldApply = process.argv.includes('--apply');
+  const token = config.blob.readWriteToken;
+
+  if (!token) {
+    console.error('❌ BLOB_READ_WRITE_TOKEN mangler i miljøet. Afbryder.');
+    process.exit(1);
+  }
+
+  console.log(`\n🔍 Mode: ${shouldApply ? 'ANVEND (--apply)' : 'DRY-RUN (ingen ændringer)'}\n`);
+
+  // Alle billeder der stadig er refereret i databasen (inkl. deaktiverede,
+  // så vi ikke lader tunge filer ligge og vente på at blive genaktiveret).
+  const rows = await query<{ id: number; image_url: string | null; is_active: boolean }>(
+    'SELECT id, image_url, is_active FROM gallery_images'
+  );
+
+  const targets = rows.filter(
+    (r): r is { id: number; image_url: string; is_active: boolean } =>
+      !!r.image_url && isGalleryBlobUrl(r.image_url)
+  );
+
+  const skipped = rows.length - targets.length;
+  console.log(
+    `📚 ${rows.length} rækker i gallery_images` +
+      (skipped > 0 ? ` (${skipped} har ingen blob-URL og springes over).` : '.')
+  );
+  console.log(`🖼️  ${targets.length} blob-billeder at behandle.\n`);
+
+  if (targets.length === 0) {
+    console.log('✅ Ingen blob-billeder at komprimere.');
+    process.exit(0);
+  }
+
+  let processed = 0;
+  let originalTotal = 0;
+  let compressedTotal = 0;
+
+  for (const row of targets) {
+    const url = row.image_url;
+    const label = url.split('/').pop() || url;
+
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        console.log(
+          `   ⚠️  #${row.id} ${label} (${row.is_active ? 'aktiv' : 'inaktiv'}): ` +
+            `kunne ikke hentes (HTTP ${res.status}), springer over.`
+        );
+        continue;
+      }
+      const original = Buffer.from(await res.arrayBuffer());
+
+      const { buffer: compressed, contentType, ext } = await compressImage(original);
+
+      const saving = original.length - compressed.length;
+      const ratio = saving / original.length;
+
+      if (ratio < MIN_SAVING_RATIO) {
+        console.log(
+          `   ⏭️  #${row.id} ${label}: allerede optimeret (${formatKB(original.length)}), springer over.`
+        );
+        continue;
+      }
+
+      processed++;
+      originalTotal += original.length;
+      compressedTotal += compressed.length;
+
+      console.log(
+        `   ${shouldApply ? '✅' : '•'} #${row.id} ${label}: ` +
+          `${formatKB(original.length)} → ${formatKB(compressed.length)} ` +
+          `(-${(ratio * 100).toFixed(0)} %)`
+      );
+
+      if (!shouldApply) continue;
+
+      // 1. Upload komprimeret som ny blob.
+      const uploaded = await put(newBlobPath(ext), compressed, {
+        access: 'public',
+        contentType,
+        token,
+      });
+
+      // 2. Peg databasen på den nye URL.
+      await execute('UPDATE gallery_images SET image_url = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2', [
+        uploaded.url,
+        row.id,
+      ]);
+
+      // 3. Slet den gamle blob (efter DB er opdateret, så vi aldrig peger på en slettet fil).
+      await del(url, { token });
+    } catch (err) {
+      console.log(`   ❌ #${row.id} ${label}: fejl — ${(err as Error).message}`);
+    }
+  }
+
+  const savedMB = ((originalTotal - compressedTotal) / 1024 / 1024).toFixed(2);
+  console.log('');
+  if (processed === 0) {
+    console.log('✅ Intet at komprimere — alle billeder er allerede optimeret.');
+  } else if (shouldApply) {
+    console.log(`🗜️  Komprimerede ${processed} billeder og sparede ${savedMB} MB pr. fuld visning.`);
+  } else {
+    console.log(
+      `ℹ️  Dry-run — ${processed} billeder ville blive komprimeret og spare ~${savedMB} MB pr. fuld visning.`
+    );
+    console.log('   Kør igen med --apply for faktisk at udføre ændringerne.');
+  }
+  console.log('');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fejl under komprimering:', err);
+  process.exit(1);
+});

--- a/server/scripts/diagnose-blobs.ts
+++ b/server/scripts/diagnose-blobs.ts
@@ -1,0 +1,106 @@
+import { head } from '@vercel/blob';
+import { query } from '../db/database.postgres';
+import { config } from '../config/env';
+
+/**
+ * Read-only diagnose af galleri-blobs. Ændrer INTET.
+ *
+ * Når `compress-blobs` melder HTTP 403 på et billede, kan det skyldes to vidt
+ * forskellige ting:
+ *   A) Filen findes stadig, men offentlig CDN-læsning er spærret
+ *      (fx blob-store over kvote/suspenderet, eller ikke offentlig).
+ *   B) Filen er reelt væk — rækken i DB peger på en slettet/ukendt blob.
+ *
+ * Testen: `head(url, { token })` går via Vercel's API (styringsplan) i stedet
+ * for den offentlige CDN. Hvis head FINDER filen, men et almindeligt `fetch`
+ * giver 403, er det tilfælde A (adgangs-/kvoteproblem, ikke manglende filer).
+ * Hvis head også fejler med not-found, er det tilfælde B (døde DB-rækker).
+ */
+async function main() {
+  const token = config.blob.readWriteToken;
+  if (!token) {
+    console.error('❌ BLOB_READ_WRITE_TOKEN mangler i miljøet. Afbryder.');
+    process.exit(1);
+  }
+
+  const rows = await query<{ id: number; image_url: string | null; is_active: boolean }>(
+    'SELECT id, image_url, is_active FROM gallery_images'
+  );
+  const targets = rows.filter(
+    (r): r is { id: number; image_url: string; is_active: boolean } =>
+      !!r.image_url && /blob\.vercel-storage\.com\//.test(r.image_url)
+  );
+
+  console.log(`\n🔎 Diagnosticerer ${targets.length} blob-billeder (read-only)…\n`);
+
+  const hosts = new Map<string, number>();
+  let existsButBlocked = 0; // head OK, fetch fejler → tilfælde A
+  let missing = 0; // head fejler → tilfælde B
+  let ok = 0; // begge OK
+
+  for (const row of targets) {
+    const url = row.image_url;
+    const label = url.split('/').pop() || url;
+    const host = (() => {
+      try {
+        return new URL(url).host;
+      } catch {
+        return '(ugyldig URL)';
+      }
+    })();
+    hosts.set(host, (hosts.get(host) ?? 0) + 1);
+
+    let fetchStatus: number | string;
+    try {
+      fetchStatus = (await fetch(url)).status;
+    } catch (err) {
+      fetchStatus = `fetch-fejl: ${(err as Error).message}`;
+    }
+
+    let headResult: string;
+    try {
+      const meta = await head(url, { token });
+      headResult = `findes (${(meta.size / 1024).toFixed(0)} KB)`;
+      if (fetchStatus === 200) ok++;
+      else existsButBlocked++;
+    } catch (err) {
+      headResult = `head-fejl: ${(err as Error).message}`;
+      missing++;
+    }
+
+    console.log(`   #${row.id} ${label} [${row.is_active ? 'aktiv' : 'inaktiv'}]`);
+    console.log(`        host: ${host}`);
+    console.log(`        fetch: HTTP ${fetchStatus}   |   head: ${headResult}`);
+  }
+
+  console.log('\n────────────── OPSUMMERING ──────────────');
+  console.log('Hosts (blob-stores) i spil:');
+  for (const [host, count] of hosts) {
+    console.log(`   • ${host}  → ${count} billeder`);
+  }
+  console.log('');
+  console.log(`   ✅ Læsbare (fetch 200):                 ${ok}`);
+  console.log(`   🔒 Findes, men fetch blokeret (A):      ${existsButBlocked}`);
+  console.log(`   👻 Findes ikke via head (B, døde rækker): ${missing}`);
+  console.log('');
+
+  if (existsButBlocked > 0 && missing === 0) {
+    console.log('➡️  Tilfælde A: Filerne findes, men offentlig læsning er spærret.');
+    console.log('   Tjek blob-storens status i Vercel-dashboardet (kvote/egress-loft/adgang).');
+    console.log('   Bekræft også at du kører mod det RIGTIGE miljø (prod vs dev).');
+  } else if (missing > 0 && existsButBlocked === 0) {
+    console.log('➡️  Tilfælde B: DB-rækkerne peger på blobs der ikke findes (døde rækker).');
+    console.log('   Disse billeder er reelt væk — overvej at fjerne/erstatte rækkerne.');
+  } else if (existsButBlocked > 0 && missing > 0) {
+    console.log('➡️  Blandet: både spærrede og manglende filer — se pr. række ovenfor.');
+  } else {
+    console.log('➡️  Alt kunne læses — intet at diagnosticere.');
+  }
+  console.log('');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fejl under diagnose:', err);
+  process.exit(1);
+});

--- a/server/services/inquiryService.test.ts
+++ b/server/services/inquiryService.test.ts
@@ -69,18 +69,18 @@ describe('InquiryService', () => {
   });
 
   describe('checkAvailability', () => {
-    it('should return true when dates are available', () => {
+    it('should return true when dates are available', async () => {
       (inquiryRepository.hasOverlap as jest.Mock).mockReturnValue(false);
 
-      const result = inquiryService.checkAvailability('2025-06-01', '2025-06-03');
+      const result = await inquiryService.checkAvailability('2025-06-01', '2025-06-03');
 
       expect(result).toBe(true);
     });
 
-    it('should return false when dates are not available', () => {
+    it('should return false when dates are not available', async () => {
       (inquiryRepository.hasOverlap as jest.Mock).mockReturnValue(true);
 
-      const result = inquiryService.checkAvailability('2025-06-01', '2025-06-03');
+      const result = await inquiryService.checkAvailability('2025-06-01', '2025-06-03');
 
       expect(result).toBe(false);
     });

--- a/server/utils/imageCompression.test.ts
+++ b/server/utils/imageCompression.test.ts
@@ -1,0 +1,61 @@
+import sharp from 'sharp';
+import { compressImage, MAX_WIDTH } from './imageCompression';
+
+/**
+ * Genererer et syntetisk JPEG-billede i fuld opløsning som stand-in for en
+ * uploadet original.
+ */
+async function makeJpeg(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 120, g: 180, b: 90 },
+    },
+  })
+    .jpeg({ quality: 100 })
+    .toBuffer();
+}
+
+describe('compressImage', () => {
+  it('nedskalerer billeder bredere end MAX_WIDTH til MAX_WIDTH', async () => {
+    const input = await makeJpeg(3000, 2000);
+
+    const { buffer } = await compressImage(input);
+    const meta = await sharp(buffer).metadata();
+
+    expect(meta.width).toBe(MAX_WIDTH);
+    // Bevarer aspect ratio (3:2).
+    expect(meta.height).toBe(Math.round((MAX_WIDTH * 2000) / 3000));
+  });
+
+  it('opskalerer ikke billeder smallere end MAX_WIDTH', async () => {
+    const input = await makeJpeg(800, 600);
+
+    const { buffer } = await compressImage(input);
+    const meta = await sharp(buffer).metadata();
+
+    expect(meta.width).toBe(800);
+    expect(meta.height).toBe(600);
+  });
+
+  it('konverterer output til WebP', async () => {
+    const input = await makeJpeg(1000, 1000);
+
+    const result = await compressImage(input);
+    const meta = await sharp(result.buffer).metadata();
+
+    expect(result.contentType).toBe('image/webp');
+    expect(result.ext).toBe('.webp');
+    expect(meta.format).toBe('webp');
+  });
+
+  it('producerer en mindre fil for et stort billede i fuld opløsning', async () => {
+    const input = await makeJpeg(3000, 2000);
+
+    const { buffer } = await compressImage(input);
+
+    expect(buffer.length).toBeLessThan(input.length);
+  });
+});

--- a/server/utils/imageCompression.ts
+++ b/server/utils/imageCompression.ts
@@ -1,0 +1,48 @@
+import sharp from 'sharp';
+
+/**
+ * Delt billedkomprimering brugt af blob-optimeringen.
+ *
+ * Galleri- og hero-billeder serveres direkte fra Vercel Blob i fuld opløsning,
+ * hvilket driver egress-forbruget op. Denne helper nedskalerer til en fornuftig
+ * maksbredde og konverterer til WebP, så hver fil bliver 10-30× mindre uden
+ * synligt kvalitetstab på et website.
+ */
+
+/** Maks. bredde i pixels. Billeder bredere end dette nedskaleres; smallere røres ikke. */
+export const MAX_WIDTH = 1600;
+
+/** WebP-kvalitet (0-100). 80 er et godt kompromis mellem størrelse og udseende. */
+export const WEBP_QUALITY = 80;
+
+export interface CompressedImage {
+  buffer: Buffer;
+  contentType: string;
+  /** Filendelse inkl. punktum, fx ".webp". */
+  ext: string;
+}
+
+/**
+ * Komprimér et billed-buffer: respektér EXIF-orientering, nedskalér til
+ * maks. MAX_WIDTH og konvertér til WebP. Returnerer altid WebP.
+ */
+export async function compressImage(input: Buffer): Promise<CompressedImage> {
+  const image = sharp(input, { failOn: 'none' });
+  const metadata = await image.metadata();
+
+  // .rotate() uden argument anvender EXIF-orienteringen og fjerner den bagefter,
+  // så billedet vender rigtigt når EXIF-data strippes ved konvertering.
+  let pipeline = image.rotate();
+
+  if (metadata.width && metadata.width > MAX_WIDTH) {
+    pipeline = pipeline.resize({ width: MAX_WIDTH, withoutEnlargement: true });
+  }
+
+  const buffer = await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer();
+
+  return {
+    buffer,
+    contentType: 'image/webp',
+    ext: '.webp',
+  };
+}


### PR DESCRIPTION
## Hvorfor

Galleri- og hero-billeder blev serveret råt fra Vercel Blob i fuld opløsning (op til 5 MB pr. fil). Det drev **egressen** op i det månedlige ~10 GB gratis-loft (ramt juli 2026), hvilket i sidste ende spærrede offentlig læsning på storen. Komprimering skærer størrelsen ~10-30× og holder egressen godt under loftet fremover.

## Hvad

**Kernen — luk hele billed-livscyklussen:**
- **Nye uploads komprimeres automatisk** — `uploadToBlob` kører nu billedet gennem en delt `sharp`-helper (resize til maks 1600px + WebP q80) før upload. Signaturen forenklet til `(buffer, originalname)`; begge kaldesteder i `galleryController` opdateret; `api/index.js`-bundlen genbygget (`sharp` forbliver `external`).
- **Eksisterende blobs** — `npm run blob:compress` komprimerer in-place: henter hver refereret blob, komprimerer, genoploader WebP, opdaterer `image_url` i DB og sletter den gamle blob. Dry-run default, `--apply` udfører. Idempotent.

**Værktøj:**
- `npm run blob:diagnose` — read-only diagnose der sammenligner `head(url,{token})` (API) vs offentlig `fetch` for at afgøre om 403'er skyldes spærret læsning (findes) vs. døde DB-rækker (findes ikke).
- `npm run prod-env -- "<cmd>"` — sikker wrapper der tager backup/restore af lokal `.env` omkring `vercel env pull` (restorer altid, også ved fejl/Ctrl+C).
- `docs/blob-egress-vurdering.md` — vurdering af Cloudflare R2 / Cloudinary vs. at blive på Blob.

**Bonus (opstod undervejs):**
- `jest.config.js` dækker nu også `server/` — det afslørede og fik rettet en forældet `inquiryService`-test (async `checkAvailability`, aldrig kørt før).
- `eslint.config.js`: `fetch`/`URL` tilføjet som globals. `sharp` tilføjet i dependencies.

## Status
- ✅ Kørt mod prod: eksisterende billeder komprimeret via `blob:compress --apply` (efter midlertidig Pro-opgradering, da egress-loftet havde spærret læsning).
- ✅ Nye uploads komprimeres nu automatisk → egress forbliver lav → kan nedgradere til Hobby igen.

## Tests
- Jest: `compressImage` dækket (resize, ingen opskalering, WebP-output, mindre fil). Fuld suite grøn (8/8).

## Noter
- Ingen DB-migration. `image_url`-rækker opdateres af komprimeringsscriptet, ikke af skema.
- Thumbnail-variant til galleri-grid er bevidst fravalgt i denne omgang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)