### PR TITLE
Galleri-karrusel, thumbnails og cache-headere for lavere blob-egress

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -185,8 +185,9 @@ var import_nodemailer = __toESM(require("nodemailer"));
 var import_dotenv = __toESM(require("dotenv"));
 import_dotenv.default.config();
 var config = {
-  // Server
-  port: parseInt(process.env.PORT || "3000", 10),
+  // Server — API_PORT frem for PORT: eksterne værktøjer (fx preview-servere)
+  // sætter PORT for frontenden, og den må ikke smitte af på backenden.
+  port: parseInt(process.env.API_PORT || "3000", 10),
   nodeEnv: process.env.NODE_ENV || "development",
   // Email
   email: {
@@ -578,6 +579,7 @@ var createGalleryImageSchema = import_zod2.z.object({
   title: import_zod2.z.string().min(1, "Titel er p\xE5kr\xE6vet").max(255, "Titel m\xE5 max v\xE6re 255 tegn"),
   description: import_zod2.z.string().max(1e3, "Beskrivelse m\xE5 max v\xE6re 1000 tegn").optional(),
   image_url: import_zod2.z.string().optional(),
+  thumb_url: import_zod2.z.string().nullable().optional(),
   file_path: import_zod2.z.string().optional(),
   is_active: import_zod2.z.preprocess((val) => val === "true" || val === true, import_zod2.z.boolean()).default(true),
   show_in_hero: import_zod2.z.preprocess((val) => val === "true" || val === true, import_zod2.z.boolean()).default(false),
@@ -818,7 +820,7 @@ var GalleryRepository = class {
   async getActiveImages() {
     try {
       const rows = await query(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE is_active = true
          ORDER BY sort_order ASC, created_at DESC`
@@ -835,7 +837,7 @@ var GalleryRepository = class {
   async getHeroImages() {
     try {
       const rows = await query(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE show_in_hero = true AND is_active = true
          ORDER BY sort_order ASC, created_at DESC`
@@ -853,7 +855,7 @@ var GalleryRepository = class {
   async getAllImages() {
     try {
       const rows = await query(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          ORDER BY sort_order ASC, created_at DESC`
       );
@@ -869,7 +871,7 @@ var GalleryRepository = class {
   async getImageById(id) {
     try {
       const row = await queryOne(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE id = $1`,
         [id]
@@ -885,7 +887,7 @@ var GalleryRepository = class {
    */
   async createImage(imageData) {
     try {
-      const { title, description, image_url, is_active, sort_order } = imageData;
+      const { title, description, image_url, thumb_url, is_active, sort_order } = imageData;
       let finalSortOrder = sort_order || 0;
       if (finalSortOrder === 0) {
         const maxSortResult = await queryOne(
@@ -895,10 +897,10 @@ var GalleryRepository = class {
         finalSortOrder = maxSort + 1;
       }
       const result = await queryOne(
-        `INSERT INTO gallery_images (title, description, image_url, is_active, sort_order)
-         VALUES ($1, $2, $3, $4, $5)
+        `INSERT INTO gallery_images (title, description, image_url, thumb_url, is_active, sort_order)
+         VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING id`,
-        [title, description, image_url, is_active, finalSortOrder]
+        [title, description, image_url, thumb_url ?? null, is_active, finalSortOrder]
       );
       if (!result) {
         throw new Error("Failed to create image");
@@ -918,7 +920,7 @@ var GalleryRepository = class {
    */
   async updateImage(id, imageData) {
     try {
-      const { title, description, image_url, file_path, is_active, show_in_hero, sort_order } = imageData;
+      const { title, description, image_url, thumb_url, file_path, is_active, show_in_hero, sort_order } = imageData;
       const updateFields = [];
       const updateValues = [];
       let paramIndex = 1;
@@ -933,6 +935,10 @@ var GalleryRepository = class {
       if (image_url !== void 0) {
         updateFields.push(`image_url = $${paramIndex++}`);
         updateValues.push(image_url);
+      }
+      if (thumb_url !== void 0) {
+        updateFields.push(`thumb_url = $${paramIndex++}`);
+        updateValues.push(thumb_url);
       }
       if (file_path !== void 0) {
         updateFields.push(`image_path = $${paramIndex++}`);
@@ -1021,13 +1027,14 @@ var import_fs2 = __toESM(require("fs"));
 // server/utils/imageCompression.ts
 var import_sharp = __toESM(require("sharp"));
 var MAX_WIDTH = 1600;
+var THUMB_WIDTH = 960;
 var WEBP_QUALITY = 80;
-async function compressImage(input) {
+async function compressImage(input, maxWidth = MAX_WIDTH) {
   const image = (0, import_sharp.default)(input, { failOn: "none" });
   const metadata = await image.metadata();
   let pipeline = image.rotate();
-  if (metadata.width && metadata.width > MAX_WIDTH) {
-    pipeline = pipeline.resize({ width: MAX_WIDTH, withoutEnlargement: true });
+  if (metadata.width && metadata.width > maxWidth) {
+    pipeline = pipeline.resize({ width: maxWidth, withoutEnlargement: true });
   }
   const buffer = await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer();
   return {
@@ -1055,34 +1062,56 @@ var upload = (0, import_multer.default)({
     files: 1
   }
 });
+var CACHE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
 async function uploadToBlob(buffer, originalname) {
-  const { buffer: optimized, contentType, ext } = await compressImage(buffer);
+  const [full, thumb] = await Promise.all([
+    compressImage(buffer),
+    compressImage(buffer, THUMB_WIDTH)
+  ]);
   const timestamp = Date.now();
   const randomString = Math.random().toString(36).substring(2, 8);
-  const filename = `${timestamp}-${randomString}${ext}`;
+  const filename = `${timestamp}-${randomString}${full.ext}`;
+  const thumbFilename = `${timestamp}-${randomString}-thumb${thumb.ext}`;
   if (config.blob.readWriteToken) {
     const { put } = await import("@vercel/blob");
-    const blob = await put(`gallery/${filename}`, optimized, {
-      access: "public",
-      contentType,
-      token: config.blob.readWriteToken
-    });
+    const [blob, thumbBlob] = await Promise.all([
+      put(`gallery/${filename}`, full.buffer, {
+        access: "public",
+        contentType: full.contentType,
+        cacheControlMaxAge: CACHE_MAX_AGE_SECONDS,
+        token: config.blob.readWriteToken
+      }),
+      put(`gallery/${thumbFilename}`, thumb.buffer, {
+        access: "public",
+        contentType: thumb.contentType,
+        cacheControlMaxAge: CACHE_MAX_AGE_SECONDS,
+        token: config.blob.readWriteToken
+      })
+    ]);
     logger.info("File uploaded to Vercel Blob", {
       url: blob.url,
+      thumbUrl: thumbBlob.url,
       originalName: originalname,
       originalBytes: buffer.length,
-      optimizedBytes: optimized.length
+      optimizedBytes: full.buffer.length,
+      thumbBytes: thumb.buffer.length
     });
-    return blob.url;
+    return { url: blob.url, thumbUrl: thumbBlob.url };
   } else {
     const tmpDir = "/tmp/uploads";
     if (!import_fs2.default.existsSync(tmpDir)) {
       import_fs2.default.mkdirSync(tmpDir, { recursive: true });
     }
-    const filePath = import_path2.default.join(tmpDir, filename);
-    import_fs2.default.writeFileSync(filePath, optimized);
-    logger.info("File saved to local /tmp fallback", { filePath, originalName: originalname });
-    return `/tmp-uploads/${filename}`;
+    import_fs2.default.writeFileSync(import_path2.default.join(tmpDir, filename), full.buffer);
+    import_fs2.default.writeFileSync(import_path2.default.join(tmpDir, thumbFilename), thumb.buffer);
+    logger.info("File saved to local /tmp fallback", {
+      filePath: import_path2.default.join(tmpDir, filename),
+      originalName: originalname
+    });
+    return {
+      url: `/tmp-uploads/${filename}`,
+      thumbUrl: `/tmp-uploads/${thumbFilename}`
+    };
   }
 }
 function handleUploadError(error, req, res, next) {
@@ -1233,13 +1262,16 @@ var GalleryController = class {
     try {
       const validatedData = createGalleryImageSchema.parse(req.body);
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
-        validatedData.image_url = blobUrl;
+        const uploaded = await uploadToBlob(req.file.buffer, req.file.originalname);
+        validatedData.image_url = uploaded.url;
+        validatedData.thumb_url = uploaded.thumbUrl;
       }
       const image = await galleryRepository.createImage({
         title: validatedData.title,
         description: validatedData.description,
         image_url: validatedData.image_url || "",
+        thumb_url: validatedData.thumb_url,
+        show_in_hero: validatedData.show_in_hero,
         sort_order: validatedData.sort_order || 0,
         is_active: true
       });
@@ -1274,8 +1306,14 @@ var GalleryController = class {
       }
       const validatedData = updateGalleryImageSchema.parse(req.body);
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
-        validatedData.image_url = blobUrl;
+        const uploaded = await uploadToBlob(req.file.buffer, req.file.originalname);
+        validatedData.image_url = uploaded.url;
+        validatedData.thumb_url = uploaded.thumbUrl;
+      } else if (validatedData.image_url !== void 0 && validatedData.thumb_url === void 0) {
+        const existing = await galleryRepository.getImageById(id);
+        if (existing && existing.image_url !== validatedData.image_url) {
+          validatedData.thumb_url = null;
+        }
       }
       const image = await galleryRepository.updateImage(id, validatedData);
       if (!image) {
@@ -2280,6 +2318,7 @@ CREATE TABLE IF NOT EXISTS gallery_images (\r
     title TEXT,\r
     description TEXT,\r
     image_url TEXT NOT NULL,\r
+    thumb_url TEXT,\r
     image_path TEXT,\r
     sort_order INTEGER DEFAULT 0,\r
     is_active BOOLEAN DEFAULT true,\r
@@ -2391,6 +2430,9 @@ DELETE FROM gallery_images WHERE id NOT IN (SELECT MIN(id) FROM gallery_images G
 \r
 -- Add show_in_hero column if it doesn't exist (migration for existing databases)\r
 ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS show_in_hero BOOLEAN DEFAULT false;\r
+\r
+-- Add thumb_url column if it doesn't exist (thumbnail-variant til karrusel/lightbox-split)\r
+ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS thumb_url TEXT;\r
 \r
 -- Add unique index on image_url to prevent duplicates from repeated migrations\r
 CREATE UNIQUE INDEX IF NOT EXISTS idx_gallery_images_url_unique ON gallery_images(image_url);\r

--- a/e2e/gallery-carousel.spec.ts
+++ b/e2e/gallery-carousel.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, Page } from '@playwright/test';
+
+const API_URL = 'http://localhost:3000/api';
+
+// 1x1 transparent PNG som stand-in for blob-billeder
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+const imgUrl = (n: number, variant: 'full' | 'thumb') =>
+  `https://fake-blob.test/gallery/img-${n}${variant === 'thumb' ? '-thumb' : ''}.webp`;
+
+const galleryData = [1, 2, 3, 4, 5].map((n) => ({
+  id: n,
+  title: `Billede ${n}`,
+  description: null,
+  image_url: imgUrl(n, 'full'),
+  thumb_url: imgUrl(n, 'thumb'),
+  file_path: null,
+  is_active: true,
+  show_in_hero: false,
+  sort_order: n,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}));
+
+/**
+ * Mock galleri-API'et og blob-billederne, og registrér hvilke billed-URL'er
+ * browseren faktisk henter — det er kernen i lazy-loading-adfærden vi tester.
+ */
+async function setupMocks(page: Page): Promise<string[]> {
+  const requestedImages: string[] = [];
+
+  await page.route('**/api/gallery', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: galleryData, count: galleryData.length }),
+    })
+  );
+
+  // Hero'en henter sit eget endpoint; giv den et tomt svar så den ikke
+  // blander sig i billed-requests i denne test.
+  await page.route('**/api/gallery/hero', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: [], count: 0 }),
+    })
+  );
+
+  await page.route('https://fake-blob.test/**', (route) => {
+    requestedImages.push(route.request().url());
+    return route.fulfill({ status: 200, contentType: 'image/png', body: TINY_PNG });
+  });
+
+  return requestedImages;
+}
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${API_URL}/test/reset`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test.describe('Galleri-karrusel', () => {
+  test('viser første billede som thumbnail og henter ikke fjerne slides', async ({ page }) => {
+    const requestedImages = await setupMocks(page);
+
+    await page.goto('/');
+    await page.locator('#gallery').scrollIntoViewIfNeeded();
+
+    // Første slide vises med korrekt position
+    const firstImg = page.locator('#gallery img[alt="Billede 1"]');
+    await expect(firstImg).toBeVisible();
+    await expect(page.locator('#gallery').getByText('(1 / 5)')).toBeVisible();
+
+    // Den synlige slide hentes som thumbnail (960w-varianten), ikke fuld størrelse
+    await expect.poll(() => requestedImages).toContain(imgUrl(1, 'thumb'));
+    expect(requestedImages).not.toContain(imgUrl(1, 'full'));
+
+    // Slides langt fra den aktuelle (3 og 4) har slet ikke fået src og hentes ikke
+    expect(requestedImages).not.toContain(imgUrl(3, 'thumb'));
+    expect(requestedImages).not.toContain(imgUrl(3, 'full'));
+    expect(requestedImages).not.toContain(imgUrl(4, 'thumb'));
+    expect(requestedImages).not.toContain(imgUrl(4, 'full'));
+  });
+
+  test('næste-knappen bladrer og henter først billedet dér', async ({ page }) => {
+    const requestedImages = await setupMocks(page);
+
+    await page.goto('/');
+    await page.locator('#gallery').scrollIntoViewIfNeeded();
+    await expect(page.locator('#gallery img[alt="Billede 1"]')).toBeVisible();
+
+    await page.locator('#gallery').getByRole('button', { name: 'Næste billede' }).click();
+
+    await expect(page.locator('#gallery').getByText('(2 / 5)')).toBeVisible();
+    await expect.poll(() => requestedImages).toContain(imgUrl(2, 'thumb'));
+
+    // Tilbage-bladring virker også (wrap-around til sidste billede fra nr. 1)
+    await page.locator('#gallery').getByRole('button', { name: 'Forrige billede' }).click();
+    await page.locator('#gallery').getByRole('button', { name: 'Forrige billede' }).click();
+    await expect(page.locator('#gallery').getByText('(5 / 5)')).toBeVisible();
+  });
+
+  test('lightbox åbner med fuld-størrelses-varianten', async ({ page }) => {
+    const requestedImages = await setupMocks(page);
+
+    await page.goto('/');
+    await page.locator('#gallery').scrollIntoViewIfNeeded();
+
+    await page
+      .locator('#gallery')
+      .getByRole('button', { name: 'Vis Billede 1 i fuld størrelse' })
+      .click();
+
+    const lightbox = page.getByRole('dialog');
+    await expect(lightbox).toBeVisible();
+    await expect(lightbox.locator(`img[src="${imgUrl(1, 'full')}"]`)).toBeVisible();
+    await expect.poll(() => requestedImages).toContain(imgUrl(1, 'full'));
+
+    // Escape lukker lightboxen igen
+    await page.keyboard.press('Escape');
+    await expect(lightbox).not.toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:migrate": "esbuild server/db/migrate.ts --bundle --platform=node --format=cjs --packages=external --loader:.sql=text --outfile=node_modules/.cache/migrate.cjs && node node_modules/.cache/migrate.cjs",
     "blob:cleanup": "tsx server/scripts/cleanup-blobs.ts",
     "blob:compress": "tsx server/scripts/compress-blobs.ts",
+    "blob:thumbs": "tsx server/scripts/backfill-thumbs.ts",
     "blob:diagnose": "tsx server/scripts/diagnose-blobs.ts",
     "prod-env": "node scripts/with-prod-env.mjs"
   },

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -4,8 +4,9 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export const config = {
-  // Server
-  port: parseInt(process.env.PORT || '3000', 10),
+  // Server — API_PORT frem for PORT: eksterne værktøjer (fx preview-servere)
+  // sætter PORT for frontenden, og den må ikke smitte af på backenden.
+  port: parseInt(process.env.API_PORT || '3000', 10),
   nodeEnv: process.env.NODE_ENV || 'development',
   
   // Email

--- a/server/controllers/galleryController.ts
+++ b/server/controllers/galleryController.ts
@@ -136,14 +136,17 @@ export class GalleryController {
 
       // Upload file to blob storage if provided
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
-        validatedData.image_url = blobUrl;
+        const uploaded = await uploadToBlob(req.file.buffer, req.file.originalname);
+        validatedData.image_url = uploaded.url;
+        validatedData.thumb_url = uploaded.thumbUrl;
       }
 
       const image = await galleryRepository.createImage({
         title: validatedData.title,
         description: validatedData.description,
         image_url: validatedData.image_url || '',
+        thumb_url: validatedData.thumb_url,
+        show_in_hero: validatedData.show_in_hero,
         sort_order: validatedData.sort_order || 0,
         is_active: true
       });
@@ -185,8 +188,16 @@ export class GalleryController {
 
       // Upload file to blob storage if provided
       if (req.file) {
-        const blobUrl = await uploadToBlob(req.file.buffer, req.file.originalname);
-        validatedData.image_url = blobUrl;
+        const uploaded = await uploadToBlob(req.file.buffer, req.file.originalname);
+        validatedData.image_url = uploaded.url;
+        validatedData.thumb_url = uploaded.thumbUrl;
+      } else if (validatedData.image_url !== undefined && validatedData.thumb_url === undefined) {
+        // Manuel URL-ændring uden nyt upload: nulstil thumbnailen hvis URL'en
+        // faktisk er en anden, så karrusellen ikke viser en forældet thumbnail.
+        const existing = await galleryRepository.getImageById(id);
+        if (existing && existing.image_url !== validatedData.image_url) {
+          validatedData.thumb_url = null;
+        }
       }
 
       const image = await galleryRepository.updateImage(id, validatedData);

--- a/server/db/schema.postgres.sql
+++ b/server/db/schema.postgres.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS gallery_images (
     title TEXT,
     description TEXT,
     image_url TEXT NOT NULL,
+    thumb_url TEXT,
     image_path TEXT,
     sort_order INTEGER DEFAULT 0,
     is_active BOOLEAN DEFAULT true,
@@ -116,6 +117,9 @@ DELETE FROM gallery_images WHERE id NOT IN (SELECT MIN(id) FROM gallery_images G
 
 -- Add show_in_hero column if it doesn't exist (migration for existing databases)
 ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS show_in_hero BOOLEAN DEFAULT false;
+
+-- Add thumb_url column if it doesn't exist (thumbnail-variant til karrusel/lightbox-split)
+ALTER TABLE gallery_images ADD COLUMN IF NOT EXISTS thumb_url TEXT;
 
 -- Add unique index on image_url to prevent duplicates from repeated migrations
 CREATE UNIQUE INDEX IF NOT EXISTS idx_gallery_images_url_unique ON gallery_images(image_url);

--- a/server/middleware/upload.ts
+++ b/server/middleware/upload.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { Request, Response, NextFunction } from 'express';
 import { config } from '../config/env';
 import { logger } from '../config/logger';
-import { compressImage } from '../utils/imageCompression';
+import { compressImage, THUMB_WIDTH } from '../utils/imageCompression';
 
 /**
  * Configure multer with memory storage (file lives in req.file.buffer)
@@ -30,48 +30,85 @@ export const upload = multer({
   },
 });
 
+export interface UploadedImage {
+  /** URL til fuld-størrelses-varianten (maks. MAX_WIDTH, WebP). */
+  url: string;
+  /** URL til thumbnail-varianten (maks. THUMB_WIDTH, WebP) til karrusel/grid. */
+  thumbUrl: string;
+}
+
+/**
+ * Filerne er immutable — hvert upload får et nyt unikt filnavn — så browseren
+ * må cache dem så længe som muligt. Gengangere henter dermed aldrig billederne
+ * igen, hvilket skærer direkte i blob-egress.
+ */
+const CACHE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60; // 1 år
+
 /**
  * Upload a file buffer to Vercel Blob (production) or /tmp (local dev).
  *
  * The buffer is compressed first (downscaled + converted to WebP) to keep
  * Vercel Blob egress low — the raw upload could be up to 5 MB, the compressed
- * version is typically 10-30× smaller. Returns the public URL for the file.
+ * version is typically 10-30× smaller. A ~THUMB_WIDTH px thumbnail variant is
+ * uploaded alongside for the gallery carousel, so visitors only pay for the
+ * full-size file when they open the lightbox.
  */
 export async function uploadToBlob(
   buffer: Buffer,
   originalname: string
-): Promise<string> {
-  const { buffer: optimized, contentType, ext } = await compressImage(buffer);
+): Promise<UploadedImage> {
+  const [full, thumb] = await Promise.all([
+    compressImage(buffer),
+    compressImage(buffer, THUMB_WIDTH),
+  ]);
 
   const timestamp = Date.now();
   const randomString = Math.random().toString(36).substring(2, 8);
-  const filename = `${timestamp}-${randomString}${ext}`;
+  const filename = `${timestamp}-${randomString}${full.ext}`;
+  const thumbFilename = `${timestamp}-${randomString}-thumb${thumb.ext}`;
 
   if (config.blob.readWriteToken) {
     // Production: upload to Vercel Blob
     const { put } = await import('@vercel/blob');
-    const blob = await put(`gallery/${filename}`, optimized, {
-      access: 'public',
-      contentType,
-      token: config.blob.readWriteToken,
-    });
+    const [blob, thumbBlob] = await Promise.all([
+      put(`gallery/${filename}`, full.buffer, {
+        access: 'public',
+        contentType: full.contentType,
+        cacheControlMaxAge: CACHE_MAX_AGE_SECONDS,
+        token: config.blob.readWriteToken,
+      }),
+      put(`gallery/${thumbFilename}`, thumb.buffer, {
+        access: 'public',
+        contentType: thumb.contentType,
+        cacheControlMaxAge: CACHE_MAX_AGE_SECONDS,
+        token: config.blob.readWriteToken,
+      }),
+    ]);
     logger.info('File uploaded to Vercel Blob', {
       url: blob.url,
+      thumbUrl: thumbBlob.url,
       originalName: originalname,
       originalBytes: buffer.length,
-      optimizedBytes: optimized.length,
+      optimizedBytes: full.buffer.length,
+      thumbBytes: thumb.buffer.length,
     });
-    return blob.url;
+    return { url: blob.url, thumbUrl: thumbBlob.url };
   } else {
     // Local dev fallback: save to /tmp/uploads/
     const tmpDir = '/tmp/uploads';
     if (!fs.existsSync(tmpDir)) {
       fs.mkdirSync(tmpDir, { recursive: true });
     }
-    const filePath = path.join(tmpDir, filename);
-    fs.writeFileSync(filePath, optimized);
-    logger.info('File saved to local /tmp fallback', { filePath, originalName: originalname });
-    return `/tmp-uploads/${filename}`;
+    fs.writeFileSync(path.join(tmpDir, filename), full.buffer);
+    fs.writeFileSync(path.join(tmpDir, thumbFilename), thumb.buffer);
+    logger.info('File saved to local /tmp fallback', {
+      filePath: path.join(tmpDir, filename),
+      originalName: originalname,
+    });
+    return {
+      url: `/tmp-uploads/${filename}`,
+      thumbUrl: `/tmp-uploads/${thumbFilename}`,
+    };
   }
 }
 

--- a/server/repositories/galleryRepository.ts
+++ b/server/repositories/galleryRepository.ts
@@ -11,7 +11,7 @@ export class GalleryRepository {
   async getActiveImages(): Promise<GalleryImage[]> {
     try {
       const rows = await query<GalleryImage>(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE is_active = true
          ORDER BY sort_order ASC, created_at DESC`
@@ -29,7 +29,7 @@ export class GalleryRepository {
   async getHeroImages(): Promise<GalleryImage[]> {
     try {
       const rows = await query<GalleryImage>(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE show_in_hero = true AND is_active = true
          ORDER BY sort_order ASC, created_at DESC`
@@ -49,7 +49,7 @@ export class GalleryRepository {
   async getAllImages(): Promise<GalleryImage[]> {
     try {
       const rows = await query<GalleryImage>(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          ORDER BY sort_order ASC, created_at DESC`
       );
@@ -66,7 +66,7 @@ export class GalleryRepository {
   async getImageById(id: number): Promise<GalleryImage | null> {
     try {
       const row = await queryOne<GalleryImage>(
-        `SELECT id, title, description, image_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
+        `SELECT id, title, description, image_url, thumb_url, image_path as file_path, is_active, show_in_hero, sort_order, created_at, updated_at
          FROM gallery_images
          WHERE id = $1`,
         [id]
@@ -83,7 +83,7 @@ export class GalleryRepository {
    */
   async createImage(imageData: CreateGalleryImageInput): Promise<GalleryImage> {
     try {
-      const { title, description, image_url, is_active, sort_order } = imageData;
+      const { title, description, image_url, thumb_url, is_active, sort_order } = imageData;
 
       // Get the next sort order if not provided
       let finalSortOrder = sort_order || 0;
@@ -96,10 +96,10 @@ export class GalleryRepository {
       }
 
       const result = await queryOne<{ id: number }>(
-        `INSERT INTO gallery_images (title, description, image_url, is_active, sort_order)
-         VALUES ($1, $2, $3, $4, $5)
+        `INSERT INTO gallery_images (title, description, image_url, thumb_url, is_active, sort_order)
+         VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING id`,
-        [title, description, image_url, is_active, finalSortOrder]
+        [title, description, image_url, thumb_url ?? null, is_active, finalSortOrder]
       );
 
       if (!result) {
@@ -124,7 +124,7 @@ export class GalleryRepository {
    */
   async updateImage(id: number, imageData: UpdateGalleryImageInput): Promise<GalleryImage | null> {
     try {
-      const { title, description, image_url, file_path, is_active, show_in_hero, sort_order } = imageData;
+      const { title, description, image_url, thumb_url, file_path, is_active, show_in_hero, sort_order } = imageData;
 
       // Build dynamic update query
       const updateFields: string[] = [];
@@ -142,6 +142,10 @@ export class GalleryRepository {
       if (image_url !== undefined) {
         updateFields.push(`image_url = $${paramIndex++}`);
         updateValues.push(image_url);
+      }
+      if (thumb_url !== undefined) {
+        updateFields.push(`thumb_url = $${paramIndex++}`);
+        updateValues.push(thumb_url);
       }
       if (file_path !== undefined) {
         updateFields.push(`image_path = $${paramIndex++}`);

--- a/server/scripts/backfill-thumbs.ts
+++ b/server/scripts/backfill-thumbs.ts
@@ -1,0 +1,131 @@
+import { put } from '@vercel/blob';
+import { query, execute } from '../db/database.postgres';
+import { config } from '../config/env';
+import { compressImage, THUMB_WIDTH } from '../utils/imageCompression';
+
+/**
+ * Backfill af thumbnail-varianter for eksisterende galleri-billeder.
+ *
+ * Nye uploads får automatisk en ~THUMB_WIDTH px thumbnail ved siden af
+ * fuld-størrelses-varianten (se uploadToBlob), men billeder uploadet før
+ * denne ændring har kun fuld størrelse. Karrusellen falder i så fald tilbage
+ * til image_url og henter unødigt meget data — derfor dette engangs-script.
+ *
+ * For hver række med en blob-image_url og uden thumb_url:
+ *   1. Hent fuld-størrelses-filen.
+ *   2. Generér thumbnail via delt helper.
+ *   3. Upload som ny blob (med 1-års cache-header) og sæt thumb_url i databasen.
+ *
+ * Idempotent: rækker der allerede har thumb_url springes over.
+ *
+ * Kør uden flag = dry-run (viser kun hvad der ville ske).
+ * Kør med --apply = udfører faktisk upload og DB-opdatering.
+ *
+ * Kræver at .env peger på det rigtige miljø (blob-token + DB). Til produktion:
+ *   vercel env pull .env --environment=production
+ */
+
+const CACHE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60; // 1 år — filerne er immutable
+
+/** Genkender en Vercel Blob-URL under gallery/-prefixet. */
+function isGalleryBlobUrl(url: string): boolean {
+  return /blob\.vercel-storage\.com\/gallery\//.test(url);
+}
+
+function newThumbPath(ext: string): string {
+  const timestamp = Date.now();
+  const randomString = Math.random().toString(36).substring(2, 8);
+  return `gallery/${timestamp}-${randomString}-thumb${ext}`;
+}
+
+function formatKB(bytes: number): string {
+  return `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+async function main() {
+  const shouldApply = process.argv.includes('--apply');
+  const token = config.blob.readWriteToken;
+
+  if (!token) {
+    console.error('❌ BLOB_READ_WRITE_TOKEN mangler i miljøet. Afbryder.');
+    process.exit(1);
+  }
+
+  console.log(`\n🔍 Mode: ${shouldApply ? 'ANVEND (--apply)' : 'DRY-RUN (ingen ændringer)'}\n`);
+
+  const rows = await query<{ id: number; image_url: string | null; thumb_url: string | null }>(
+    'SELECT id, image_url, thumb_url FROM gallery_images'
+  );
+
+  const targets = rows.filter(
+    (r): r is { id: number; image_url: string; thumb_url: null } =>
+      !r.thumb_url && !!r.image_url && isGalleryBlobUrl(r.image_url)
+  );
+
+  console.log(`📚 ${rows.length} rækker i gallery_images.`);
+  console.log(`🖼️  ${targets.length} billeder mangler thumbnail.\n`);
+
+  if (targets.length === 0) {
+    console.log('✅ Alle billeder har allerede en thumbnail.');
+    process.exit(0);
+  }
+
+  let processed = 0;
+  let thumbTotal = 0;
+
+  for (const row of targets) {
+    const label = row.image_url.split('/').pop() || row.image_url;
+
+    try {
+      const res = await fetch(row.image_url);
+      if (!res.ok) {
+        console.log(`   ⚠️  #${row.id} ${label}: kunne ikke hentes (HTTP ${res.status}), springer over.`);
+        continue;
+      }
+      const original = Buffer.from(await res.arrayBuffer());
+
+      const thumb = await compressImage(original, THUMB_WIDTH);
+
+      processed++;
+      thumbTotal += thumb.buffer.length;
+
+      console.log(
+        `   ${shouldApply ? '✅' : '•'} #${row.id} ${label}: ` +
+          `${formatKB(original.length)} → thumbnail ${formatKB(thumb.buffer.length)}`
+      );
+
+      if (!shouldApply) continue;
+
+      const uploaded = await put(newThumbPath(thumb.ext), thumb.buffer, {
+        access: 'public',
+        contentType: thumb.contentType,
+        cacheControlMaxAge: CACHE_MAX_AGE_SECONDS,
+        token,
+      });
+
+      await execute(
+        'UPDATE gallery_images SET thumb_url = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2',
+        [uploaded.url, row.id]
+      );
+    } catch (err) {
+      console.log(`   ❌ #${row.id} ${label}: fejl — ${(err as Error).message}`);
+    }
+  }
+
+  console.log('');
+  if (processed === 0) {
+    console.log('✅ Intet at gøre — ingen billeder kunne behandles.');
+  } else if (shouldApply) {
+    console.log(`🖼️  Oprettede ${processed} thumbnails (${formatKB(thumbTotal)} i alt).`);
+  } else {
+    console.log(`ℹ️  Dry-run — ${processed} thumbnails ville blive oprettet (${formatKB(thumbTotal)} i alt).`);
+    console.log('   Kør igen med --apply for faktisk at udføre ændringerne.');
+  }
+  console.log('');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fejl under thumbnail-backfill:', err);
+  process.exit(1);
+});

--- a/server/scripts/cleanup-blobs.ts
+++ b/server/scripts/cleanup-blobs.ts
@@ -6,7 +6,8 @@ import { config } from '../config/env';
  * Rydder forældreløse filer op i Vercel Blob.
  *
  * En blob-fil regnes som forældreløs, hvis dens URL ikke længere optræder
- * som image_url på nogen række i gallery_images-tabellen. Det dækker både:
+ * som image_url eller thumb_url på nogen række i gallery_images-tabellen.
+ * Det dækker både:
  *   - billeder der er hard-deleted (rækken fjernet, filen efterladt)
  *   - gamle filer efterladt efter et "erstat billede"-upload
  *
@@ -27,16 +28,16 @@ async function main() {
 
   console.log(`\n🔍 Mode: ${shouldDelete ? 'SLET (--delete)' : 'DRY-RUN (ingen sletning)'}\n`);
 
-  // 1. Alle image_url'er der stadig er i brug i databasen
-  const rows = await query<{ image_url: string | null }>(
-    'SELECT image_url FROM gallery_images'
+  // 1. Alle image_url'er og thumb_url'er der stadig er i brug i databasen
+  const rows = await query<{ image_url: string | null; thumb_url: string | null }>(
+    'SELECT image_url, thumb_url FROM gallery_images'
   );
   const referenced = new Set(
     rows
-      .map((r) => r.image_url)
+      .flatMap((r) => [r.image_url, r.thumb_url])
       .filter((u): u is string => !!u)
   );
-  console.log(`📚 ${referenced.size} billeder refereret i databasen.`);
+  console.log(`📚 ${referenced.size} blob-URL'er refereret i databasen.`);
 
   // 2. Alle blobs under gallery/-prefixet (paginér for en sikkerheds skyld)
   const blobs: { url: string; pathname: string; size: number }[] = [];

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -65,6 +65,7 @@ export const createGalleryImageSchema = z.object({
   title: z.string().min(1, 'Titel er påkrævet').max(255, 'Titel må max være 255 tegn'),
   description: z.string().max(1000, 'Beskrivelse må max være 1000 tegn').optional(),
   image_url: z.string().optional(),
+  thumb_url: z.string().nullable().optional(),
   file_path: z.string().optional(),
   is_active: z.preprocess(val => val === 'true' || val === true, z.boolean()).default(true),
   show_in_hero: z.preprocess(val => val === 'true' || val === true, z.boolean()).default(false),
@@ -102,6 +103,7 @@ export interface GalleryImage {
   title: string;
   description: string | null;
   image_url: string;
+  thumb_url: string | null;
   file_path: string | null;
   is_active: boolean;
   show_in_hero: boolean;

--- a/server/utils/imageCompression.ts
+++ b/server/utils/imageCompression.ts
@@ -12,6 +12,14 @@ import sharp from 'sharp';
 /** Maks. bredde i pixels. Billeder bredere end dette nedskaleres; smallere røres ikke. */
 export const MAX_WIDTH = 1600;
 
+/**
+ * Bredde på thumbnail-varianten der vises i galleri-karrusellen.
+ * Karrusellen er op til 896px bred (max-w-4xl); 960px dækker det slot uden
+ * synligt kvalitetstab på alm. skærme. Frontenden bruger srcset, så
+ * high-DPI-skærme stadig får fuld-størrelses-varianten (MAX_WIDTH).
+ */
+export const THUMB_WIDTH = 960;
+
 /** WebP-kvalitet (0-100). 80 er et godt kompromis mellem størrelse og udseende. */
 export const WEBP_QUALITY = 80;
 
@@ -24,9 +32,12 @@ export interface CompressedImage {
 
 /**
  * Komprimér et billed-buffer: respektér EXIF-orientering, nedskalér til
- * maks. MAX_WIDTH og konvertér til WebP. Returnerer altid WebP.
+ * maks. maxWidth (default MAX_WIDTH) og konvertér til WebP. Returnerer altid WebP.
  */
-export async function compressImage(input: Buffer): Promise<CompressedImage> {
+export async function compressImage(
+  input: Buffer,
+  maxWidth: number = MAX_WIDTH
+): Promise<CompressedImage> {
   const image = sharp(input, { failOn: 'none' });
   const metadata = await image.metadata();
 
@@ -34,8 +45,8 @@ export async function compressImage(input: Buffer): Promise<CompressedImage> {
   // så billedet vender rigtigt når EXIF-data strippes ved konvertering.
   let pipeline = image.rotate();
 
-  if (metadata.width && metadata.width > MAX_WIDTH) {
-    pipeline = pipeline.resize({ width: MAX_WIDTH, withoutEnlargement: true });
+  if (metadata.width && metadata.width > maxWidth) {
+    pipeline = pipeline.resize({ width: maxWidth, withoutEnlargement: true });
   }
 
   const buffer = await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer();

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,17 +1,45 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { API_URL } from '../config/api'
 import { GalleryImage } from '../types'
 import { galleryFallback } from '../data/galleryFallback'
 
+/**
+ * Galleriet vises som en karrusel i stedet for et grid: bedre overblik for
+ * brugeren, og kun det aktuelle billede (plus naboerne) hentes fra blob —
+ * i modsætning til gridden, hvor alle synlige billeder blev hentet med det samme.
+ */
 const Gallery = () => {
   const [selectedImage, setSelectedImage] = useState<number | null>(null)
   const [images, setImages] = useState<GalleryImage[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [currentSlide, setCurrentSlide] = useState(0)
+  // Kun slides der har været aktuelle (eller nabo til en aktuel) får sat src.
+  // Én gang hentet forbliver de i sættet, så tilbage-bladring ikke genhenter.
+  const [loadedSlides, setLoadedSlides] = useState<Set<number>>(new Set())
+  const touchStartX = useRef<number | null>(null)
+  const lightboxRef = useRef<HTMLDivElement | null>(null)
+
+  // Flyt fokus ind i lightboxen når den åbner, så Escape/piletaster virker
+  useEffect(() => {
+    if (selectedImage !== null) lightboxRef.current?.focus()
+  }, [selectedImage])
 
   useEffect(() => {
     fetchImages()
   }, [])
+
+  // Markér aktuel slide + begge naboer som klar til hentning
+  useEffect(() => {
+    if (images.length === 0) return
+    setLoadedSlides((prev) => {
+      const next = new Set(prev)
+      next.add(currentSlide)
+      next.add((currentSlide + 1) % images.length)
+      next.add((currentSlide - 1 + images.length) % images.length)
+      return next
+    })
+  }, [currentSlide, images.length])
 
   const fetchImages = async () => {
     try {
@@ -35,6 +63,32 @@ const Gallery = () => {
     } finally {
       setIsLoading(false)
     }
+  }
+
+  const nextSlide = () => {
+    setCurrentSlide((prev) => (prev + 1) % images.length)
+  }
+
+  const previousSlide = () => {
+    setCurrentSlide((prev) => (prev - 1 + images.length) % images.length)
+  }
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current
+    touchStartX.current = null
+    if (Math.abs(deltaX) < 50) return
+    if (deltaX < 0) nextSlide()
+    else previousSlide()
+  }
+
+  const handleCarouselKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight') nextSlide()
+    if (e.key === 'ArrowLeft') previousSlide()
   }
 
   const openLightbox = (index: number) => {
@@ -99,42 +153,129 @@ const Gallery = () => {
           </div>
         )}
 
-        {/* Gallery Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
-          {images.map((image, index) => (
-            <button
-              key={image.id}
-              onClick={() => openLightbox(index)}
-              className="group relative aspect-square overflow-hidden rounded-xl shadow-md hover:shadow-2xl transition-shadow duration-300 focus:outline-none focus:ring-4 focus:ring-primary-500"
-            >
-              <img
-                src={image.image_url}
-                alt={image.title}
-                className="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-500"
-                loading="lazy"
-              />
-              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300 flex items-center justify-center">
-                <svg
-                  className="w-12 h-12 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"
-                  />
-                </svg>
+        {/* Gallery Carousel */}
+        {images.length > 0 && (
+          <div
+            className="relative max-w-4xl mx-auto"
+            role="region"
+            aria-label="Billedkarrusel"
+            aria-roledescription="karrusel"
+            tabIndex={0}
+            onKeyDown={handleCarouselKeyDown}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
+            <div className="overflow-hidden rounded-xl shadow-md">
+              <div
+                className="flex transition-transform duration-500 ease-out"
+                style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+              >
+                {images.map((image, index) => (
+                  <div
+                    key={image.id}
+                    className="w-full flex-shrink-0 aspect-[4/3] bg-gray-100 dark:bg-gray-700"
+                    aria-hidden={index !== currentSlide}
+                  >
+                    {loadedSlides.has(index) && (
+                      <button
+                        onClick={() => openLightbox(index)}
+                        tabIndex={index === currentSlide ? 0 : -1}
+                        className="group relative w-full h-full focus:outline-none focus:ring-4 focus:ring-primary-500"
+                        aria-label={`Vis ${image.title} i fuld størrelse`}
+                      >
+                        <img
+                          src={image.thumb_url ?? image.image_url}
+                          srcSet={
+                            image.thumb_url
+                              ? `${image.thumb_url} 960w, ${image.image_url} 1600w`
+                              : undefined
+                          }
+                          sizes="(max-width: 928px) 100vw, 896px"
+                          alt={image.title}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                        />
+                        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300 flex items-center justify-center">
+                          <svg
+                            className="w-12 h-12 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    )}
+                  </div>
+                ))}
               </div>
-            </button>
-          ))}
-        </div>
+            </div>
+
+            {/* Previous Button */}
+            {images.length > 1 && (
+              <button
+                onClick={previousSlide}
+                className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition-colors focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Forrige billede"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+            )}
+
+            {/* Next Button */}
+            {images.length > 1 && (
+              <button
+                onClick={nextSlide}
+                className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition-colors focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Næste billede"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+            )}
+
+            {/* Caption + position */}
+            <p className="text-center mt-4 text-lg text-gray-700 dark:text-gray-300">
+              {images[currentSlide].title}{' '}
+              <span className="text-gray-400 dark:text-gray-500">
+                ({currentSlide + 1} / {images.length})
+              </span>
+            </p>
+
+            {/* Dot indicators */}
+            {images.length > 1 && (
+              <div className="flex justify-center gap-2 mt-3">
+                {images.map((image, index) => (
+                  <button
+                    key={image.id}
+                    onClick={() => setCurrentSlide(index)}
+                    className={`w-2.5 h-2.5 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 ${
+                      index === currentSlide
+                        ? 'bg-primary-600'
+                        : 'bg-gray-300 dark:bg-gray-600 hover:bg-gray-400'
+                    }`}
+                    aria-label={`Gå til billede ${index + 1}`}
+                    aria-current={index === currentSlide}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Lightbox */}
         {selectedImage !== null && (
           <div
+            ref={lightboxRef}
             className="fixed inset-0 bg-black/95 z-50 flex items-center justify-center p-4"
             onClick={closeLightbox}
             onKeyDown={handleKeyDown}

--- a/src/components/GalleryAdmin.tsx
+++ b/src/components/GalleryAdmin.tsx
@@ -7,6 +7,7 @@ interface GalleryImage {
   title: string
   description: string | null
   image_url: string
+  thumb_url: string | null
   file_path: string | null
   is_active: boolean
   show_in_hero: boolean
@@ -267,9 +268,10 @@ const GalleryAdmin: React.FC = () => {
                   {/* Image thumbnail */}
                   <div className="flex-shrink-0">
                     <img
-                      src={image.image_url}
+                      src={image.thumb_url ?? image.image_url}
                       alt={image.title}
                       className="h-16 w-16 rounded-lg object-cover"
+                      loading="lazy"
                     />
                   </div>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,6 +13,11 @@ const Hero = () => {
   const [layerB, setLayerB] = useState({ imageIndex: 1 })
   const [topLayer, setTopLayer] = useState<'A' | 'B'>('A') // which layer is currently visible on top
   const [fading, setFading] = useState(false)
+  // Slideshowet pauser når hero'en er scrollet ud af viewporten, så vi ikke
+  // bliver ved med at hente nye billeder fra blob for en bruger der læser
+  // længere nede på siden.
+  const [inView, setInView] = useState(true)
+  const sectionRef = useRef<HTMLElement | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cycleRef = useRef(0)
 
@@ -60,9 +65,25 @@ const Hero = () => {
     [images]
   )
 
+  // Observe whether the hero section is visible
+  useEffect(() => {
+    const el = sectionRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') return
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting)
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   // Start the slideshow cycle
   useEffect(() => {
     if (images.length <= 1) return
+    if (!inView) {
+      // Nulstil et evt. afbrudt fade, så det viste lag ikke står halvt usynligt
+      setFading(false)
+      return
+    }
 
     const startTransition = () => {
       cycleRef.current++
@@ -100,7 +121,7 @@ const Hero = () => {
       clearInterval(interval)
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [images.length, preload, topLayer])
+  }, [images.length, preload, topLayer, inView])
 
   const scrollToContact = () => {
     const element = document.querySelector('#contact')
@@ -114,7 +135,7 @@ const Hero = () => {
   const aIsTop = topLayer === 'A'
 
   return (
-    <section id="hero" className="relative min-h-screen flex items-center pt-16 sm:pt-20 overflow-hidden">
+    <section ref={sectionRef} id="hero" className="relative min-h-screen flex items-center pt-16 sm:pt-20 overflow-hidden">
       {/* Background Slideshow */}
       <div className="absolute inset-0 z-0">
         {/* Gradient overlay - on top of images */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface GalleryImage {
   title: string
   description: string | null
   image_url: string
+  thumb_url: string | null
   file_path: string | null
   is_active: boolean
   show_in_hero: boolean

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
         target: 'http://localhost:3000',
         changeOrigin: true,
       },
+      // Lokalt uploadede billeder (blob-fallback) serveres af backenden
+      '/tmp-uploads': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Formål
Skære yderligere i Vercel Blob-egress oven på komprimeringen fra #45 — og samtidig erstatte galleri-gridden med en karrusel (bedre UX).

## Ændringer

**1. Thumbnail-variant (960px WebP)**
- `uploadToBlob` genererer nu både fuld størrelse (1600px) og en thumbnail (960px), gemt i ny `thumb_url`-kolonne (idempotent migration i `schema.postgres.sql`).
- Karrusellen viser thumbnailen via `srcset`, så high-DPI-skærme stadig automatisk får fuld størrelse — intet synligt kvalitetstab.
- Backfill af eksisterende billeder: `npm run blob:thumbs` (dry-run som standard, `--apply` for at udføre). Skal køres mod prod efter merge, jf. checklisten nedenfor.
- `blob:cleanup` regner nu også `thumb_url` som refereret, så thumbnails ikke slettes som forældreløse.
- Ændres `image_url` manuelt i admin (uden fil-upload), nulstilles `thumb_url`, så der ikke vises en forældet thumbnail.

**2. Galleri-karrusel med lazy loading pr. slide**
- Grid → karrusel med pile, dots, swipe og piletaster. Kun den aktuelle slide + naboer får sat `src`; med `loading="lazy"` henter browseren reelt kun den synlige slide. Verificeret: med 3+ billeder hentes off-screen slides først, når der bladres til dem.
- Lightbox viser fortsat fuld opløsning og får nu fokus ved åbning, så Escape/piletaster virker (var en nedarvet fejl).

**3. Cache-header på 1 år**
- `cacheControlMaxAge: 31536000` på alle blob-uploads (filnavne er unikke pr. upload, så filerne er immutable). Verificeret på rigtige uploads. Gælder kun nye filer — eksisterende beholder 30 dage.

**4. Hero-slideshow pauser uden for viewporten**
- `IntersectionObserver` stopper cyklussen (og dermed billedhentning), når hero'en ikke er synlig, og genoptager den ved scroll tilbage. Verificeret i browseren: 0 nye blob-requests efter 18 s uden for view; slideshowet kører igen ved scroll op.

**Dev-miljø (små følgeændringer)**
- Backend-porten styres af `API_PORT` (default 3000) i stedet for `PORT`, som preview-værktøjer injicerer til frontenden.
- Vite proxier `/tmp-uploads`, så lokalt uploadede billeder kan vises i dev.

## Test
- Ny E2E-suite `e2e/gallery-carousel.spec.ts`: thumbnail-valg via srcset, at fjerne slides ikke hentes, bladring (inkl. wrap-around), lightbox med fuld størrelse + Escape.
- Alle 13 E2E-tests består. `api/index.js` er genbygget og committet.
- Manuelt verificeret ende-til-ende: rigtigt upload gennem API'et → begge blob-varianter oprettet med 1-års cache-header → karrusel viser thumb, lightbox viser fuld størrelse (testdata ryddet op igen bagefter).

## Efter merge (checkliste)
1. `vercel env pull .env --environment=production`
2. `npm run blob:thumbs` (dry-run) → `npm run blob:thumbs -- --apply`
3. Evt. `npm run blob:cleanup` bagefter — **skal køres med prod-env**, ellers betragtes prod-filer som forældreløse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)