### PR TITLE
Tekstopdateringer: opredning, Kongeåen og drikkevarer

### DIFF
--- a/src/components/Facilities.tsx
+++ b/src/components/Facilities.tsx
@@ -89,6 +89,14 @@ const Facilities = () => {
                   <span>Cykelrute 10 &amp; 11 går næsten lige forbi</span>
                 </li>
                 <li className="flex items-start">
+                  <LucideIcons.Fish className="w-6 h-6 text-primary-600 dark:text-primary-400 mr-3 flex-shrink-0" />
+                  <span>1,5 km til Kongeåen, hvor der er mulighed for at vandre på Kongeåstien, samt lystfiskeri. Fisk må rengøres i udekøkken</span>
+                </li>
+                <li className="flex items-start">
+                  <LucideIcons.Coffee className="w-6 h-6 text-primary-600 dark:text-primary-400 mr-3 flex-shrink-0" />
+                  <span>Drikkevarer på køl til indkøbspris samt fri kaffe og te</span>
+                </li>
+                <li className="flex items-start">
                   <LucideIcons.AlertTriangle className="w-6 h-6 text-amber-600 dark:text-amber-400 mr-3 flex-shrink-0" />
                   <span>Færdsel i haven er på eget ansvar</span>
                 </li>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -28,7 +28,7 @@ const sleepOptions: SleepOption[] = [
   {
     icon: BedDouble,
     title: 'Ét shelter med opredning',
-    description: 'Madras med færdig opredning — dyne, pude og lagner.',
+    description: 'Madras med opredning — dyne, pude og sengetøj.',
     priceDkk: 100,
     priceEur: 15,
   },


### PR DESCRIPTION
## Tekstopdateringer

Tre indholdsændringer på forsiden (kun frontend, ingen server/API-ændringer):

### Priser (`Pricing.tsx`)
- "Madras med færdig opredning — dyne, pude og lagner." → **"Madras med opredning — dyne, pude og sengetøj."**

### Faciliteter → Praktiske Oplysninger (`Facilities.tsx`)
- Tilføjet: **"1,5 km til Kongeåen, hvor der er mulighed for at vandre på Kongeåstien, samt lystfiskeri. Fisk må rengøres i udekøkken"**
- Tilføjet: **"Drikkevarer på køl til indkøbspris samt fri kaffe og te"**

Verificeret i lokal preview.

### Ikke inkluderet (kræver admin, ikke kode)
Følgende to punkter fra opgavelisten er **facilitets-data i databasen** og rettes af Elin selv via admin-panelet:
- "Anretterkøkken" → "Tekøkken"
- Tilføj "kogeplade" til beskrivelsen af "Udekøkken"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
